### PR TITLE
Deploy NBT viewer to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-nbt-viewer.yml
+++ b/.github/workflows/deploy-nbt-viewer.yml
@@ -45,6 +45,16 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+      - name: Install wasm target
+        run: rustup target add wasm32-unknown-unknown
+        working-directory: .
+
+      - name: Cache Rust build
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy-nbt-viewer.yml
+++ b/.github/workflows/deploy-nbt-viewer.yml
@@ -1,0 +1,79 @@
+name: Deploy NBT Viewer
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/deploy-nbt-viewer.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/nbt-sim-wasm/**'
+      - 'src/**'
+      - 'tools/nbt-viewer/**'
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/nbt-viewer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tools/nbt-viewer/package-lock.json
+
+      - name: Install wasm-bindgen CLI
+        run: cargo install wasm-bindgen-cli --version 0.2.100 --locked
+        working-directory: .
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build WASM simulator
+        run: npm run build:wasm
+
+      - name: Build viewer
+        run: npm run build
+        env:
+          VITE_BASE_PATH: /redstone-compiler/
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: tools/nbt-viewer/dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-nbt-viewer.yml
+++ b/.github/workflows/deploy-nbt-viewer.yml
@@ -69,6 +69,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Prepare Minecraft block assets
+        run: |
+          if [ -d "$MCMETA_SOURCE_DIR" ]; then
+            npm run prepare:mcmeta
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "::warning::Skipping mcmeta asset preparation because $MCMETA_SOURCE_DIR does not exist."
+          else
+            echo "::error::Missing mcmeta asset source at $MCMETA_SOURCE_DIR."
+            exit 1
+          fi
+        env:
+          MCMETA_SOURCE_DIR: ${{ github.workspace }}/tools/nbt-viewer/public/mcmeta-source
+
       - name: Build WASM simulator
         run: npm run build:wasm
 

--- a/.github/workflows/deploy-nbt-viewer.yml
+++ b/.github/workflows/deploy-nbt-viewer.yml
@@ -2,6 +2,14 @@ name: Deploy NBT Viewer
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/deploy-nbt-viewer.yml'
+      - 'Cargo.lock'
+      - 'Cargo.toml'
+      - 'crates/nbt-sim-wasm/**'
+      - 'src/**'
+      - 'tools/nbt-viewer/**'
   push:
     branches:
       - master
@@ -60,14 +68,17 @@ jobs:
           VITE_BASE_PATH: /redstone-compiler/
 
       - name: Setup Pages
+        if: github.event_name != 'pull_request'
         uses: actions/configure-pages@v5
 
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3
         with:
           path: tools/nbt-viewer/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/crates/nbt-sim-wasm/src/lib.rs
+++ b/crates/nbt-sim-wasm/src/lib.rs
@@ -1,4 +1,7 @@
+use redstone_compiler::graph::graphviz::ToGraphvizGraph;
+use redstone_compiler::graph::world::WorldGraphBuilder;
 use redstone_compiler::nbt::{NBTRoot, ToNBT};
+use redstone_compiler::transform::place_and_route::utils::world_to_logic;
 use redstone_compiler::world::block::BlockKind;
 use redstone_compiler::world::position::Position;
 use redstone_compiler::world::simulator::{SimulationSnapshot, SimulationTraceEntry, Simulator};
@@ -27,6 +30,12 @@ struct TraceReport {
 struct SnapshotInfo {
     cycle: usize,
     root: NBTRoot,
+}
+
+#[derive(Serialize)]
+struct GraphDotInfo {
+    world_dot: String,
+    logic_dot: String,
 }
 
 #[wasm_bindgen]
@@ -83,6 +92,19 @@ impl NbtSimulator {
         };
 
         serde_wasm_bindgen::to_value(&report).map_err(to_js_error)
+    }
+
+    pub fn graph_dot(nbt_bytes: &[u8]) -> Result<JsValue, JsValue> {
+        let nbt = NBTRoot::from_nbt_bytes(nbt_bytes).map_err(to_js_error)?;
+        let world = nbt.to_world();
+        let world_graph = WorldGraphBuilder::new(&world).build();
+        let logic_graph = world_to_logic(&world).map_err(to_js_error)?;
+        let graph_dot = GraphDotInfo {
+            world_dot: world_graph.to_graphviz(),
+            logic_dot: logic_graph.to_graphviz(),
+        };
+
+        serde_wasm_bindgen::to_value(&graph_dot).map_err(to_js_error)
     }
 
     pub fn switches(&self) -> Result<JsValue, JsValue> {

--- a/tools/nbt-viewer/README.md
+++ b/tools/nbt-viewer/README.md
@@ -71,3 +71,20 @@ NBT files to a server.
 npm.cmd run build:wasm
 npm.cmd run build
 ```
+
+## GitHub Pages
+
+The viewer can be deployed as a static GitHub Pages artifact. The deployment
+workflow builds the Rust simulator WASM first, then runs the Vite production
+build so these generated files are included under `dist/wasm/nbt-sim`.
+
+For repository Pages, build with the repository subpath as the Vite base:
+
+```powershell
+$env:VITE_BASE_PATH = "/redstone-compiler/"
+npm.cmd run build:wasm
+npm.cmd run build
+```
+
+The GitHub Actions workflow uses the same base path and publishes
+`tools/nbt-viewer/dist`.

--- a/tools/nbt-viewer/package-lock.json
+++ b/tools/nbt-viewer/package-lock.json
@@ -8,6 +8,7 @@
       "name": "redstone-nbt-viewer",
       "version": "0.1.0",
       "dependencies": {
+        "@viz-js/viz": "^3.27.0",
         "deepslate": "^0.25.1",
         "gl-matrix": "^3.4.4"
       },
@@ -762,6 +763,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@viz-js/viz": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/@viz-js/viz/-/viz-3.27.0.tgz",
+      "integrity": "sha512-XjU8elLpbRieto/kHYWqT01yXDDYBTZB/Ny8ZUuheQw3Kc61I5Eto5+3Lb1PMdjEkh+DKA4Or5b2kxUY3cEfnA==",
       "license": "MIT"
     },
     "node_modules/charenc": {

--- a/tools/nbt-viewer/package.json
+++ b/tools/nbt-viewer/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview --host 127.0.0.1"
   },
   "dependencies": {
+    "@viz-js/viz": "^3.27.0",
     "deepslate": "^0.25.1",
     "gl-matrix": "^3.4.4"
   },

--- a/tools/nbt-viewer/scripts/prepare-mcmeta-from-vscode-cache.mjs
+++ b/tools/nbt-viewer/scripts/prepare-mcmeta-from-vscode-cache.mjs
@@ -1,13 +1,8 @@
 import { copyFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-const localAppData = process.env.LOCALAPPDATA;
-if (!localAppData) {
-  throw new Error('LOCALAPPDATA is not set.');
-}
-
 const version = process.argv[2] ?? '1.18.2';
-const sourceRoot = join(localAppData, 'vscode-nbt-nodejs', 'Cache', 'mcmeta');
+const sourceRoot = process.env.MCMETA_SOURCE_DIR ?? defaultSourceRoot();
 const targetRoot = join(process.cwd(), 'public', 'mcmeta');
 const files = ['assets', 'atlas', 'blocks', 'uvmapping'];
 
@@ -19,3 +14,12 @@ for (const file of files) {
 
 await copyFile(join(sourceRoot, 'versions'), join(targetRoot, 'versions'));
 console.log(`Copied vscode-nbt mcmeta cache for ${version} to ${targetRoot}`);
+
+function defaultSourceRoot() {
+  const localAppData = process.env.LOCALAPPDATA;
+  if (!localAppData) {
+    throw new Error('LOCALAPPDATA is not set. Set MCMETA_SOURCE_DIR to a mcmeta cache directory.');
+  }
+
+  return join(localAppData, 'vscode-nbt-nodejs', 'Cache', 'mcmeta');
+}

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -126,6 +126,7 @@ const traceCycleInput = document.querySelector<HTMLInputElement>('#trace-cycle')
 const traceCycleLabel = document.querySelector<HTMLElement>('#trace-cycle-label')!;
 const tracePrevButton = document.querySelector<HTMLButtonElement>('#trace-prev')!;
 const traceNextButton = document.querySelector<HTMLButtonElement>('#trace-next')!;
+const switchesPanel = document.querySelector<HTMLDetailsElement>('#switches-panel')!;
 const switchesList = document.querySelector<HTMLElement>('#switches-list')!;
 const switchesCount = document.querySelector<HTMLElement>('#switches-count')!;
 
@@ -467,11 +468,13 @@ function renderSwitches(structure?: StructureModel): void {
   switchesCount.textContent = switches.length === 0 ? 'No switches' : `${switches.length} switches`;
 
   if (switches.length === 0) {
+    switchesPanel.open = false;
     switchesList.className = 'switches-list empty';
     switchesList.textContent = structure ? 'No switches in this NBT file.' : 'Open an NBT file to control switches.';
     return;
   }
 
+  switchesPanel.open = true;
   switchesList.className = 'switches-list';
   switches.forEach((block, index) => {
     const row = document.createElement('button');

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -161,6 +161,7 @@ async function toggleSelectedSwitch(): Promise<void> {
 
   simulation ??= await NbtSimulation.create(currentNbtBytes);
 
+  const selectedPos = selectedBlock.pos;
   const baseRoot = currentRoot;
   const nextRoot = simulation.toggleSwitch(selectedBlock);
   if (!nextRoot) return;
@@ -169,16 +170,9 @@ async function toggleSelectedSwitch(): Promise<void> {
   const structure = toStructureModel(currentRoot);
   if (!structure) throw new Error('Simulator returned a structure that the viewer could not render.');
 
-  await viewer.setStructure(structure);
-  selectedBlock = undefined;
-  renderSelection(undefined);
+  await viewer.setStructure(structure, { preserveSelection: true, preserveView: true });
+  renderSelection(structure.blocks.find(block => samePos(block.pos, selectedPos)));
   renderTrace(simulation.trace(), simulation.snapshots(), baseRoot);
-  inspector.textContent = [
-    `updated by simulator`,
-    `size: ${structure.size.join(' x ')}`,
-    `palette: ${structure.palette.length}`,
-    `blocks: ${structure.blocks.length}`,
-  ].join('\n');
 }
 
 dropZone.addEventListener('dragover', event => {
@@ -434,6 +428,10 @@ function renderSelection(block: StructureBlock | undefined): void {
 
 function getLeverPowered(block: StructureBlock | undefined): boolean {
   return block?.palette.properties?.powered === 'true';
+}
+
+function samePos(a: [number, number, number], b: [number, number, number]): boolean {
+  return a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
 }
 
 function renderSimulationError(error: unknown): void {

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -44,6 +44,12 @@ interface DroppedFileSystemDirectoryHandle {
 }
 
 type DroppedFileSystemHandle = DroppedFileSystemFileHandle | DroppedFileSystemDirectoryHandle;
+type TraceAnimation = {
+  timer: number;
+  token: number;
+};
+
+const TRACE_ANIMATION_INTERVAL_MS = 100;
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <main class="app-shell">
@@ -126,6 +132,8 @@ let traceCycles: number[] = [];
 let currentSnapshots: SnapshotInfo[] = [];
 let traceBaseRoot: unknown;
 let isTracePreviewActive = false;
+let traceAnimation: TraceAnimation | undefined;
+let traceAnimationToken = 0;
 
 folderInput.setAttribute('webkitdirectory', '');
 folderInput.setAttribute('directory', '');
@@ -146,15 +154,18 @@ toggleSwitchButton.addEventListener('click', () => {
 });
 
 traceCycleInput.addEventListener('input', () => {
+  cancelTraceAnimation();
   void renderTraceCycle(Number(traceCycleInput.value));
 });
 
 tracePrevButton.addEventListener('click', () => {
+  cancelTraceAnimation();
   traceCycleInput.value = String(Math.max(0, Number(traceCycleInput.value) - 1));
   void renderTraceCycle(Number(traceCycleInput.value));
 });
 
 traceNextButton.addEventListener('click', () => {
+  cancelTraceAnimation();
   traceCycleInput.value = String(Math.min(traceCycles.length - 1, Number(traceCycleInput.value) + 1));
   void renderTraceCycle(Number(traceCycleInput.value));
 });
@@ -175,7 +186,7 @@ async function toggleSelectedSwitch(): Promise<void> {
 
   await viewer.setStructure(structure, { preserveSelection: true, preserveView: true });
   renderSelection(structure.blocks.find(block => samePos(block.pos, selectedPos)));
-  renderTrace(simulation.trace(), simulation.snapshots(), baseRoot, { select: 'last' });
+  renderTrace(simulation.trace(), simulation.snapshots(), baseRoot, { animateTo: 'last' });
 }
 
 dropZone.addEventListener('dragover', event => {
@@ -451,15 +462,16 @@ function renderTrace(
   trace: TraceEntry[],
   snapshots: SnapshotInfo[],
   baseRoot: unknown,
-  options: { open?: boolean; select?: 'first' | 'last' } = {},
+  options: { animateTo?: 'last'; open?: boolean; select?: 'first' | 'last' } = {},
 ): void {
+  cancelTraceAnimation();
   currentTrace = trace;
   currentSnapshots = snapshots;
   traceBaseRoot = baseRoot;
   traceCycles = Array.from(new Set(trace.map(entry => entry.cycle))).sort((a, b) => a - b);
   traceCount.textContent = trace.length === 0 ? 'No events' : `${trace.length} events`;
   traceCycleInput.max = String(Math.max(0, traceCycles.length - 1));
-  const selectedIndex = options.select === 'last' ? traceCycles.length - 1 : 0;
+  const selectedIndex = options.animateTo === 'last' ? 0 : options.select === 'last' ? traceCycles.length - 1 : 0;
   traceCycleInput.value = String(Math.max(0, selectedIndex));
   traceCycleInput.disabled = traceCycles.length === 0;
   tracePrevButton.disabled = traceCycles.length === 0;
@@ -468,6 +480,37 @@ function renderTrace(
   if (options.open || trace.length > 0) {
     tracePanel.open = true;
   }
+  if (options.animateTo === 'last') {
+    startTraceAnimation(traceCycles.length - 1);
+  }
+}
+
+function cancelTraceAnimation(): void {
+  if (!traceAnimation) return;
+
+  window.clearInterval(traceAnimation.timer);
+  traceAnimation = undefined;
+  traceAnimationToken += 1;
+}
+
+function startTraceAnimation(targetIndex: number): void {
+  if (targetIndex <= 0) return;
+
+  const token = traceAnimationToken + 1;
+  traceAnimationToken = token;
+  traceAnimation = {
+    token,
+    timer: window.setInterval(() => {
+      if (!traceAnimation || traceAnimation.token !== token) return;
+
+      const currentIndex = Number(traceCycleInput.value);
+      const nextIndex = Math.min(targetIndex, currentIndex + 1);
+      void renderTraceCycle(nextIndex);
+      if (nextIndex >= targetIndex) {
+        cancelTraceAnimation();
+      }
+    }, TRACE_ANIMATION_INTERVAL_MS),
+  };
 }
 
 async function renderTraceCycle(index: number): Promise<void> {

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -77,7 +77,7 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
           </div>
           <button id="open-graphs" class="file-button graph-button" type="button">Graphs</button>
         </div>
-        <details id="switches-panel" class="floating-panel switches-panel">
+        <details id="switches-panel" class="floating-panel switches-panel" open>
           <summary>
             <span>Switches</span>
             <span id="switches-count">No switches</span>
@@ -241,6 +241,12 @@ openGraphsButton.addEventListener('click', () => {
 
 closeGraphsButton.addEventListener('click', () => {
   graphDialog.close();
+});
+
+graphDialog.addEventListener('click', event => {
+  if (event.target === graphDialog) {
+    graphDialog.close();
+  }
 });
 
 graphWorldTab.addEventListener('click', () => {
@@ -746,7 +752,7 @@ function renderSwitches(structure?: StructureModel): void {
   switchesCount.textContent = switches.length === 0 ? 'No switches' : `${switches.length} switches`;
 
   if (switches.length === 0) {
-    switchesPanel.open = false;
+    switchesPanel.open = !structure;
     switchesList.className = 'switches-list empty';
     switchesList.textContent = structure ? 'No switches in this NBT file.' : 'Open an NBT file to control switches.';
     return;

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -85,7 +85,10 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
             <button id="trace-next" type="button" aria-label="Next cycle">Next</button>
             <span id="trace-cycle-label">cycle -</span>
           </div>
-          <pre id="trace-output">Run a simulation to inspect events.</pre>
+          <details class="trace-log">
+            <summary>Log</summary>
+            <pre id="trace-output">Run a simulation to inspect events.</pre>
+          </details>
         </details>
         <div id="viewer-empty" class="viewer-empty">Drop an .nbt file or use Open NBT.</div>
       </section>

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -51,14 +51,10 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
       <section class="viewer-panel">
         <canvas id="structure-canvas"></canvas>
         <div class="floating-actions">
-          <label class="file-button">
-            Open Folder
-            <input id="folder-input" type="file" multiple />
-          </label>
-          <label class="file-button">
-            Open NBT
-            <input id="file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
-          </label>
+          <button id="open-folder" class="file-button" type="button">Open Folder</button>
+          <button id="open-file" class="file-button" type="button">Open NBT</button>
+          <input id="folder-input" class="hidden-file-input" type="file" multiple />
+          <input id="file-input" class="hidden-file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
         </div>
         <details id="files-panel" class="floating-panel files-panel">
           <summary>
@@ -95,6 +91,8 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 
 const input = document.querySelector<HTMLInputElement>('#file-input')!;
 const folderInput = document.querySelector<HTMLInputElement>('#folder-input')!;
+const openFileButton = document.querySelector<HTMLButtonElement>('#open-file')!;
+const openFolderButton = document.querySelector<HTMLButtonElement>('#open-folder')!;
 const dropZone = document.querySelector<HTMLElement>('#drop-zone')!;
 const filesPanel = document.querySelector<HTMLDetailsElement>('#files-panel')!;
 const filesList = document.querySelector<HTMLElement>('#files-list')!;
@@ -126,6 +124,16 @@ let isTracePreviewActive = false;
 
 folderInput.setAttribute('webkitdirectory', '');
 folderInput.setAttribute('directory', '');
+
+openFileButton.addEventListener('click', () => {
+  input.value = '';
+  input.click();
+});
+
+openFolderButton.addEventListener('click', () => {
+  folderInput.value = '';
+  folderInput.click();
+});
 
 input.addEventListener('change', () => {
   const file = input.files?.[0];

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -49,7 +49,7 @@ type TraceAnimation = {
   token: number;
 };
 
-const TRACE_ANIMATION_INTERVAL_MS = 100;
+const TRACE_ANIMATION_INTERVAL_MS = 50;
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <main class="app-shell">

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -3,7 +3,7 @@ import { loadNbtFile, stringifyNbt } from './nbt/loadNbt';
 import { toStructureModel } from './nbt/toStructure';
 import { StructureViewer } from './render/StructureViewer';
 import { NbtSimulation, NbtSimulationError, type SnapshotInfo, type TraceEntry } from './sim/NbtSimulation';
-import type { StructureBlock, StructurePaletteEntry } from './types';
+import type { StructureBlock, StructureModel, StructurePaletteEntry } from './types';
 
 interface DroppedFileSystemEntry {
   readonly fullPath: string;
@@ -66,6 +66,13 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
             <input id="file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
           </label>
         </div>
+        <details id="switches-panel" class="floating-panel switches-panel">
+          <summary>
+            <span>Switches</span>
+            <span id="switches-count">No switches</span>
+          </summary>
+          <div id="switches-list" class="switches-list empty">Open an NBT file to control switches.</div>
+        </details>
         <details id="files-panel" class="floating-panel files-panel">
           <summary>
             <span>Files</span>
@@ -119,6 +126,8 @@ const traceCycleInput = document.querySelector<HTMLInputElement>('#trace-cycle')
 const traceCycleLabel = document.querySelector<HTMLElement>('#trace-cycle-label')!;
 const tracePrevButton = document.querySelector<HTMLButtonElement>('#trace-prev')!;
 const traceNextButton = document.querySelector<HTMLButtonElement>('#trace-next')!;
+const switchesList = document.querySelector<HTMLElement>('#switches-list')!;
+const switchesCount = document.querySelector<HTMLElement>('#switches-count')!;
 
 const viewer = new StructureViewer(canvas);
 viewer.setSelectionHandler(renderSelection);
@@ -173,11 +182,17 @@ traceNextButton.addEventListener('click', () => {
 async function toggleSelectedSwitch(): Promise<void> {
   if (!selectedBlock || !currentNbtBytes) return;
 
+  await toggleSwitchBlock(selectedBlock);
+}
+
+async function toggleSwitchBlock(block: StructureBlock): Promise<void> {
+  if (!currentNbtBytes) return;
+
   simulation ??= await NbtSimulation.create(currentNbtBytes);
 
-  const selectedPos = selectedBlock.pos;
+  const selectedPos = block.pos;
   const baseRoot = currentRoot;
-  const nextRoot = simulation.toggleSwitch(selectedBlock);
+  const nextRoot = simulation.toggleSwitch(block);
   if (!nextRoot) return;
 
   currentRoot = mergeSimulatedState(currentRoot, nextRoot);
@@ -185,7 +200,10 @@ async function toggleSelectedSwitch(): Promise<void> {
   if (!structure) throw new Error('Simulator returned a structure that the viewer could not render.');
 
   await viewer.setStructure(structure, { preserveSelection: true, preserveView: true });
-  renderSelection(structure.blocks.find(block => samePos(block.pos, selectedPos)));
+  const nextSelectedBlock = structure.blocks.find(block => samePos(block.pos, selectedPos));
+  viewer.setSelectedBlock(nextSelectedBlock);
+  renderSelection(nextSelectedBlock);
+  renderSwitches(structure);
   renderTrace(simulation.trace(), simulation.snapshots(), baseRoot, { animateTo: 'last' });
 }
 
@@ -388,6 +406,7 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
 
     if (structure) {
       await viewer.setStructure(structure);
+      renderSwitches(structure);
       viewerEmpty.classList.add('hidden');
       inspector.textContent = [
         `size: ${structure.size.join(' x ')}`,
@@ -398,6 +417,7 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
     } else {
       viewerEmpty.classList.remove('hidden');
       inspector.textContent = 'This NBT file does not look like a Minecraft structure file.';
+      renderSwitches();
       renderTrace([], [], undefined);
     }
   } catch (error) {
@@ -408,6 +428,7 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
     toggleSwitchButton.classList.add('hidden');
     viewerEmpty.classList.remove('hidden');
     inspector.textContent = error instanceof Error ? error.message : String(error);
+    renderSwitches();
     renderTrace([], [], undefined);
   }
 }
@@ -437,6 +458,42 @@ function renderSelection(block: StructureBlock | undefined): void {
     name: block.palette.name,
     properties: block.palette.properties,
     nbt: block.nbt,
+  });
+}
+
+function renderSwitches(structure?: StructureModel): void {
+  switchesList.replaceChildren();
+  const switches = structure?.blocks.filter(block => block.palette.name === 'minecraft:lever') ?? [];
+  switchesCount.textContent = switches.length === 0 ? 'No switches' : `${switches.length} switches`;
+
+  if (switches.length === 0) {
+    switchesList.className = 'switches-list empty';
+    switchesList.textContent = structure ? 'No switches in this NBT file.' : 'Open an NBT file to control switches.';
+    return;
+  }
+
+  switchesList.className = 'switches-list';
+  switches.forEach((block, index) => {
+    const row = document.createElement('button');
+    row.className = 'switch-entry';
+    row.type = 'button';
+    if (selectedBlock && samePos(block.pos, selectedBlock.pos)) row.classList.add('selected');
+
+    const label = document.createElement('span');
+    label.className = 'switch-entry-label';
+    label.textContent = `#${index + 1}  ${block.pos.join(',')}`;
+
+    const state = document.createElement('span');
+    state.className = 'switch-entry-state';
+    state.textContent = (simulation?.getSwitch(block)?.is_on ?? getLeverPowered(block)) ? 'On' : 'Off';
+
+    row.append(label, state);
+    row.addEventListener('click', () => {
+      void toggleSwitchBlock(block).catch(error => {
+        renderSimulationError(error);
+      });
+    });
+    switchesList.append(row);
   });
 }
 

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -51,10 +51,14 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
       <section class="viewer-panel">
         <canvas id="structure-canvas"></canvas>
         <div class="floating-actions">
-          <button id="open-folder" class="file-button" type="button">Open Folder</button>
-          <button id="open-file" class="file-button" type="button">Open NBT</button>
-          <input id="folder-input" class="hidden-file-input" type="file" multiple />
-          <input id="file-input" class="hidden-file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
+          <label class="file-button">
+            Open Folder
+            <input id="folder-input" type="file" multiple />
+          </label>
+          <label class="file-button">
+            Open NBT
+            <input id="file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
+          </label>
         </div>
         <details id="files-panel" class="floating-panel files-panel">
           <summary>
@@ -91,8 +95,6 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
 
 const input = document.querySelector<HTMLInputElement>('#file-input')!;
 const folderInput = document.querySelector<HTMLInputElement>('#folder-input')!;
-const openFileButton = document.querySelector<HTMLButtonElement>('#open-file')!;
-const openFolderButton = document.querySelector<HTMLButtonElement>('#open-folder')!;
 const dropZone = document.querySelector<HTMLElement>('#drop-zone')!;
 const filesPanel = document.querySelector<HTMLDetailsElement>('#files-panel')!;
 const filesList = document.querySelector<HTMLElement>('#files-list')!;
@@ -124,16 +126,6 @@ let isTracePreviewActive = false;
 
 folderInput.setAttribute('webkitdirectory', '');
 folderInput.setAttribute('directory', '');
-
-openFileButton.addEventListener('click', () => {
-  input.value = '';
-  input.click();
-});
-
-openFolderButton.addEventListener('click', () => {
-  folderInput.value = '';
-  folderInput.click();
-});
 
 input.addEventListener('change', () => {
   const file = input.files?.[0];

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -1,8 +1,15 @@
 import './styles.css';
+import type { Viz } from '@viz-js/viz';
 import { loadNbtFile, stringifyNbt } from './nbt/loadNbt';
 import { toStructureModel } from './nbt/toStructure';
 import { StructureViewer } from './render/StructureViewer';
-import { NbtSimulation, NbtSimulationError, type SnapshotInfo, type TraceEntry } from './sim/NbtSimulation';
+import {
+  NbtSimulation,
+  NbtSimulationError,
+  type GraphDotInfo,
+  type SnapshotInfo,
+  type TraceEntry,
+} from './sim/NbtSimulation';
 import type { StructureBlock, StructureModel, StructurePaletteEntry } from './types';
 
 interface DroppedFileSystemEntry {
@@ -48,6 +55,7 @@ type TraceAnimation = {
   timer: number;
   token: number;
 };
+type GraphTab = 'world' | 'logic';
 
 const TRACE_ANIMATION_INTERVAL_MS = 50;
 
@@ -57,14 +65,17 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
       <section class="viewer-panel">
         <canvas id="structure-canvas"></canvas>
         <div class="floating-actions">
-          <label class="file-button">
-            Open Folder
-            <input id="folder-input" type="file" multiple />
-          </label>
-          <label class="file-button">
-            Open NBT
-            <input id="file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
-          </label>
+          <div class="file-actions-row">
+            <label class="file-button">
+              Open Folder
+              <input id="folder-input" type="file" multiple />
+            </label>
+            <label class="file-button">
+              Open NBT
+              <input id="file-input" type="file" accept=".nbt,.dat,.schem,.schematic,.litematic,.mcstructure" />
+            </label>
+          </div>
+          <button id="open-graphs" class="file-button graph-button" type="button">Graphs</button>
         </div>
         <details id="switches-panel" class="floating-panel switches-panel">
           <summary>
@@ -106,6 +117,31 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
         <div id="viewer-empty" class="viewer-empty">Drop an .nbt file or use Open NBT.</div>
       </section>
     </section>
+    <dialog id="graph-dialog" class="graph-dialog">
+      <div class="graph-dialog-surface">
+        <header class="graph-dialog-header">
+          <strong>Graphs</strong>
+          <button id="close-graphs" class="panel-action" type="button">Close</button>
+        </header>
+        <div class="graph-tabs" role="tablist" aria-label="Graph views">
+          <button id="graph-world-tab" class="graph-tab active" type="button" role="tab">World Graph</button>
+          <button id="graph-logic-tab" class="graph-tab" type="button" role="tab">Logic Graph</button>
+          <div class="graph-zoom-controls" aria-label="Graph zoom">
+            <button id="graph-zoom-out" class="graph-zoom-button" type="button" aria-label="Zoom out">-</button>
+            <button id="graph-zoom-reset" class="graph-zoom-value" type="button" aria-label="Reset zoom">100%</button>
+            <button id="graph-zoom-in" class="graph-zoom-button" type="button" aria-label="Zoom in">+</button>
+          </div>
+        </div>
+        <div id="graph-status" class="graph-status">Open an NBT file to inspect graphs.</div>
+        <div class="graph-viewer">
+          <div id="graph-output" class="graph-output"></div>
+          <div id="graph-minimap" class="graph-minimap hidden" aria-hidden="true">
+            <div id="graph-minimap-content" class="graph-minimap-content"></div>
+            <div id="graph-minimap-viewport" class="graph-minimap-viewport"></div>
+          </div>
+        </div>
+      </div>
+    </dialog>
   </main>
 `;
 
@@ -129,6 +165,19 @@ const traceNextButton = document.querySelector<HTMLButtonElement>('#trace-next')
 const switchesPanel = document.querySelector<HTMLDetailsElement>('#switches-panel')!;
 const switchesList = document.querySelector<HTMLElement>('#switches-list')!;
 const switchesCount = document.querySelector<HTMLElement>('#switches-count')!;
+const openGraphsButton = document.querySelector<HTMLButtonElement>('#open-graphs')!;
+const closeGraphsButton = document.querySelector<HTMLButtonElement>('#close-graphs')!;
+const graphDialog = document.querySelector<HTMLDialogElement>('#graph-dialog')!;
+const graphWorldTab = document.querySelector<HTMLButtonElement>('#graph-world-tab')!;
+const graphLogicTab = document.querySelector<HTMLButtonElement>('#graph-logic-tab')!;
+const graphZoomOutButton = document.querySelector<HTMLButtonElement>('#graph-zoom-out')!;
+const graphZoomResetButton = document.querySelector<HTMLButtonElement>('#graph-zoom-reset')!;
+const graphZoomInButton = document.querySelector<HTMLButtonElement>('#graph-zoom-in')!;
+const graphStatus = document.querySelector<HTMLElement>('#graph-status')!;
+const graphOutput = document.querySelector<HTMLElement>('#graph-output')!;
+const graphMinimap = document.querySelector<HTMLElement>('#graph-minimap')!;
+const graphMinimapContent = document.querySelector<HTMLElement>('#graph-minimap-content')!;
+const graphMinimapViewport = document.querySelector<HTMLElement>('#graph-minimap-viewport')!;
 
 const viewer = new StructureViewer(canvas);
 viewer.setSelectionHandler(renderSelection);
@@ -144,6 +193,12 @@ let traceBaseRoot: unknown;
 let isTracePreviewActive = false;
 let traceAnimation: TraceAnimation | undefined;
 let traceAnimationToken = 0;
+let graphDot: GraphDotInfo | undefined;
+let graphTab: GraphTab = 'world';
+let vizPromise: Promise<Viz> | undefined;
+let graphMinimapScale = 1;
+let isDraggingGraphMinimap = false;
+let graphZoom = 1;
 
 folderInput.setAttribute('webkitdirectory', '');
 folderInput.setAttribute('directory', '');
@@ -179,6 +234,225 @@ traceNextButton.addEventListener('click', () => {
   traceCycleInput.value = String(Math.min(traceCycles.length - 1, Number(traceCycleInput.value) + 1));
   void renderTraceCycle(Number(traceCycleInput.value));
 });
+
+openGraphsButton.addEventListener('click', () => {
+  void openGraphDialog();
+});
+
+closeGraphsButton.addEventListener('click', () => {
+  graphDialog.close();
+});
+
+graphWorldTab.addEventListener('click', () => {
+  void setGraphTab('world');
+});
+
+graphLogicTab.addEventListener('click', () => {
+  void setGraphTab('logic');
+});
+
+graphZoomOutButton.addEventListener('click', () => {
+  setGraphZoom(graphZoom - 0.25);
+});
+
+graphZoomResetButton.addEventListener('click', () => {
+  setGraphZoom(1);
+});
+
+graphZoomInButton.addEventListener('click', () => {
+  setGraphZoom(graphZoom + 0.25);
+});
+
+graphOutput.addEventListener('scroll', () => {
+  updateGraphMinimapViewport();
+});
+
+graphMinimap.addEventListener('pointerdown', event => {
+  if (graphMinimap.classList.contains('hidden')) return;
+
+  isDraggingGraphMinimap = true;
+  graphMinimap.setPointerCapture(event.pointerId);
+  scrollGraphFromMinimap(event);
+});
+
+graphMinimap.addEventListener('pointermove', event => {
+  if (!isDraggingGraphMinimap) return;
+
+  scrollGraphFromMinimap(event);
+});
+
+graphMinimap.addEventListener('pointerup', event => {
+  isDraggingGraphMinimap = false;
+  graphMinimap.releasePointerCapture(event.pointerId);
+});
+
+graphMinimap.addEventListener('pointercancel', event => {
+  isDraggingGraphMinimap = false;
+  graphMinimap.releasePointerCapture(event.pointerId);
+});
+
+async function openGraphDialog(): Promise<void> {
+  if (!graphDialog.open) graphDialog.showModal();
+
+  if (!currentNbtBytes) {
+    graphDot = undefined;
+    graphOutput.replaceChildren();
+    graphStatus.textContent = 'Open an NBT file before viewing graphs.';
+    updateGraphTabs();
+    return;
+  }
+
+  if (!graphDot) {
+    graphOutput.replaceChildren();
+    graphStatus.textContent = 'Generating graphs...';
+    try {
+      graphDot = await NbtSimulation.graphDot(currentNbtBytes);
+    } catch (error) {
+      graphStatus.textContent = error instanceof Error ? error.message : String(error);
+      return;
+    }
+  }
+
+  await renderGraphTab();
+}
+
+async function setGraphTab(nextTab: GraphTab): Promise<void> {
+  graphTab = nextTab;
+  updateGraphTabs();
+  await renderGraphTab();
+}
+
+async function renderGraphTab(): Promise<void> {
+  updateGraphTabs();
+  graphOutput.replaceChildren();
+  clearGraphMinimap();
+
+  if (!graphDot) {
+    graphStatus.textContent = currentNbtBytes ? 'Generating graphs...' : 'Open an NBT file before viewing graphs.';
+    return;
+  }
+
+  graphStatus.textContent = graphTab === 'logic' ? 'Logic Graph' : 'World Graph';
+
+  try {
+    const dot = graphTab === 'logic' ? graphDot.logicDot : graphDot.worldDot;
+    const viz = await loadViz();
+    const svg = viz.renderSVGElement(dot, { engine: 'dot' });
+    graphOutput.append(svg);
+    applyGraphZoom();
+    renderGraphMinimap(svg);
+  } catch (error) {
+    graphStatus.textContent = error instanceof Error ? error.message : String(error);
+  }
+}
+
+async function loadViz(): Promise<Viz> {
+  vizPromise ??= import('@viz-js/viz').then(module => module.instance());
+  return vizPromise;
+}
+
+function setGraphZoom(nextZoom: number): void {
+  graphZoom = Math.max(0.25, Math.min(3, nextZoom));
+  applyGraphZoom({ refreshMinimap: true });
+}
+
+function applyGraphZoom(options: { refreshMinimap?: boolean } = {}): void {
+  graphZoomResetButton.textContent = `${Math.round(graphZoom * 100)}%`;
+  graphZoomOutButton.disabled = graphZoom <= 0.25;
+  graphZoomInButton.disabled = graphZoom >= 3;
+
+  const svg = graphOutput.querySelector<SVGSVGElement>('svg');
+  if (svg) {
+    const baseWidth = readGraphBaseSize(svg, 'width');
+    const baseHeight = readGraphBaseSize(svg, 'height');
+    svg.style.width = `${baseWidth * graphZoom}px`;
+    svg.style.height = `${baseHeight * graphZoom}px`;
+    requestAnimationFrame(() => {
+      if (options.refreshMinimap) {
+        renderGraphMinimap(svg);
+      } else {
+        updateGraphMinimapViewport();
+      }
+    });
+    return;
+  }
+
+}
+
+function readGraphBaseSize(svg: SVGSVGElement, dimension: 'width' | 'height'): number {
+  const dataKey = `base${dimension[0].toUpperCase()}${dimension.slice(1)}`;
+  const cached = Number(svg.dataset[dataKey]);
+  if (Number.isFinite(cached) && cached > 0) return cached;
+
+  const rect = svg.getBoundingClientRect();
+  const measured = dimension === 'width' ? rect.width : rect.height;
+  const fallback = dimension === 'width' ? graphOutput.clientWidth : graphOutput.clientHeight;
+  const value = Math.max(measured / graphZoom, fallback, 1);
+  svg.dataset[dataKey] = String(value);
+  return value;
+}
+
+function renderGraphMinimap(svg: SVGSVGElement): void {
+  graphMinimapContent.replaceChildren();
+  const clone = svg.cloneNode(true) as SVGSVGElement;
+  graphMinimapContent.append(clone);
+  graphMinimap.classList.remove('hidden');
+
+  requestAnimationFrame(() => {
+    const contentWidth = Math.max(graphOutput.scrollWidth, 1);
+    const contentHeight = Math.max(graphOutput.scrollHeight, 1);
+    const minimapWidth = graphMinimapContent.clientWidth;
+    const minimapHeight = graphMinimapContent.clientHeight;
+    graphMinimapScale = Math.min(minimapWidth / contentWidth, minimapHeight / contentHeight);
+
+    clone.style.width = `${contentWidth * graphMinimapScale}px`;
+    clone.style.height = `${contentHeight * graphMinimapScale}px`;
+    updateGraphMinimapViewport();
+  });
+}
+
+function updateGraphMinimapViewport(): void {
+  if (graphMinimap.classList.contains('hidden')) return;
+
+  graphMinimapViewport.style.width = `${graphOutput.clientWidth * graphMinimapScale}px`;
+  graphMinimapViewport.style.height = `${graphOutput.clientHeight * graphMinimapScale}px`;
+  graphMinimapViewport.style.transform = `translate(${graphOutput.scrollLeft * graphMinimapScale}px, ${
+    graphOutput.scrollTop * graphMinimapScale
+  }px)`;
+}
+
+function scrollGraphFromMinimap(event: PointerEvent): void {
+  event.preventDefault();
+  if (graphMinimapScale <= 0) return;
+
+  const minimapContentBox = graphMinimapContent.getBoundingClientRect();
+  const x = Math.max(0, Math.min(minimapContentBox.width, event.clientX - minimapContentBox.left));
+  const y = Math.max(0, Math.min(minimapContentBox.height, event.clientY - minimapContentBox.top));
+  graphOutput.scrollLeft = x / graphMinimapScale - graphOutput.clientWidth / 2;
+  graphOutput.scrollTop = y / graphMinimapScale - graphOutput.clientHeight / 2;
+  updateGraphMinimapViewport();
+}
+
+function clearGraphMinimap(): void {
+  graphMinimap.classList.add('hidden');
+  graphMinimapContent.replaceChildren();
+  graphMinimapViewport.removeAttribute('style');
+  graphMinimapScale = 1;
+  isDraggingGraphMinimap = false;
+}
+
+function updateGraphTabs(): void {
+  const tabs: Array<[HTMLButtonElement, GraphTab]> = [
+    [graphWorldTab, 'world'],
+    [graphLogicTab, 'logic'],
+  ];
+
+  for (const [button, tab] of tabs) {
+    const active = tab === graphTab;
+    button.classList.toggle('active', active);
+    button.setAttribute('aria-selected', String(active));
+  }
+}
 
 async function toggleSelectedSwitch(): Promise<void> {
   if (!selectedBlock || !currentNbtBytes) return;
@@ -402,6 +676,8 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
     simulation = undefined;
     currentNbtBytes = parsed.bytes;
     currentRoot = parsed.root;
+    graphDot = undefined;
+    graphTab = 'world';
 
     markSelectedFile(selectedEntry);
 
@@ -425,6 +701,8 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
     simulation = undefined;
     currentNbtBytes = undefined;
     currentRoot = undefined;
+    graphDot = undefined;
+    graphTab = 'world';
     selectedBlock = undefined;
     toggleSwitchButton.classList.add('hidden');
     viewerEmpty.classList.remove('hidden');

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -175,7 +175,7 @@ async function toggleSelectedSwitch(): Promise<void> {
 
   await viewer.setStructure(structure, { preserveSelection: true, preserveView: true });
   renderSelection(structure.blocks.find(block => samePos(block.pos, selectedPos)));
-  renderTrace(simulation.trace(), simulation.snapshots(), baseRoot);
+  renderTrace(simulation.trace(), simulation.snapshots(), baseRoot, { select: 'last' });
 }
 
 dropZone.addEventListener('dragover', event => {
@@ -440,26 +440,32 @@ function samePos(a: [number, number, number], b: [number, number, number]): bool
 function renderSimulationError(error: unknown): void {
   if (error instanceof NbtSimulationError) {
     inspector.textContent = error.message;
-    renderTrace(error.trace, error.snapshots, currentRoot, true);
+    renderTrace(error.trace, error.snapshots, currentRoot, { open: true });
     return;
   }
 
   inspector.textContent = error instanceof Error ? error.message : String(error);
 }
 
-function renderTrace(trace: TraceEntry[], snapshots: SnapshotInfo[], baseRoot: unknown, open = false): void {
+function renderTrace(
+  trace: TraceEntry[],
+  snapshots: SnapshotInfo[],
+  baseRoot: unknown,
+  options: { open?: boolean; select?: 'first' | 'last' } = {},
+): void {
   currentTrace = trace;
   currentSnapshots = snapshots;
   traceBaseRoot = baseRoot;
   traceCycles = Array.from(new Set(trace.map(entry => entry.cycle))).sort((a, b) => a - b);
   traceCount.textContent = trace.length === 0 ? 'No events' : `${trace.length} events`;
   traceCycleInput.max = String(Math.max(0, traceCycles.length - 1));
-  traceCycleInput.value = '0';
+  const selectedIndex = options.select === 'last' ? traceCycles.length - 1 : 0;
+  traceCycleInput.value = String(Math.max(0, selectedIndex));
   traceCycleInput.disabled = traceCycles.length === 0;
   tracePrevButton.disabled = traceCycles.length === 0;
   traceNextButton.disabled = traceCycles.length === 0;
-  void renderTraceCycle(traceCycles.length === 0 ? -1 : 0);
-  if (open || trace.length > 0) {
+  void renderTraceCycle(traceCycles.length === 0 ? -1 : selectedIndex);
+  if (options.open || trace.length > 0) {
     tracePanel.open = true;
   }
 }

--- a/tools/nbt-viewer/src/render/StructureViewer.ts
+++ b/tools/nbt-viewer/src/render/StructureViewer.ts
@@ -104,6 +104,11 @@ export class StructureViewer {
     this.render();
   }
 
+  setSelectedBlock(block: StructureBlock | undefined): void {
+    this.selectedBlock = block ? vec3.fromValues(block.pos[0], block.pos[1], block.pos[2]) : undefined;
+    this.render();
+  }
+
   private async initialize(): Promise<void> {
     const resources = await this.resourcesPromise;
     this.renderer = new StructureRenderer(this.gl, this.structure, resources);

--- a/tools/nbt-viewer/src/render/mcmeta.ts
+++ b/tools/nbt-viewer/src/render/mcmeta.ts
@@ -41,6 +41,10 @@ async function loadImageData(url: string): Promise<ImageData> {
   return context.getImageData(0, 0, canvas.width, canvas.height);
 }
 
+function resolveAssetPath(path: string): string {
+  return new URL(`${import.meta.env.BASE_URL}${path}`, window.location.origin).href;
+}
+
 function upperPowerOfTwo(value: number): number {
   let result = 1;
   while (result < value) result *= 2;
@@ -78,13 +82,16 @@ export class MinecraftResources {
 
   static async load(version = '1.18.2'): Promise<MinecraftResources> {
     const [blocks, assets, uvMapping, atlasImage] = await Promise.all([
-      fetchStringifiedJson<BlocksData>(`/mcmeta/${version}-blocks`, 'stringifiedBlocks'),
-      fetchStringifiedJson<Omit<McmetaAssets, 'textures'>>(`/mcmeta/${version}-assets`, 'stringifiedAssets'),
+      fetchStringifiedJson<BlocksData>(resolveAssetPath(`mcmeta/${version}-blocks`), 'stringifiedBlocks'),
+      fetchStringifiedJson<Omit<McmetaAssets, 'textures'>>(
+        resolveAssetPath(`mcmeta/${version}-assets`),
+        'stringifiedAssets',
+      ),
       fetchStringifiedJson<Record<string, [number, number, number, number]>>(
-        `/mcmeta/${version}-uvmapping`,
+        resolveAssetPath(`mcmeta/${version}-uvmapping`),
         'stringifiedUvmapping',
       ),
-      loadImageData(`/mcmeta/${version}-atlas`),
+      loadImageData(resolveAssetPath(`mcmeta/${version}-atlas`)),
     ]);
 
     const idMap: Record<string, [number, number, number, number]> = {};

--- a/tools/nbt-viewer/src/sim/NbtSimulation.ts
+++ b/tools/nbt-viewer/src/sim/NbtSimulation.ts
@@ -4,6 +4,7 @@ type WasmModule = {
   default: (moduleOrPath?: string | URL | Request | Response | WebAssembly.Module) => Promise<unknown>;
   NbtSimulator: {
     new (nbtBytes: Uint8Array): WasmSimulator;
+    graph_dot(nbtBytes: Uint8Array): RawGraphDotInfo;
     trace_init(nbtBytes: Uint8Array): TraceReport;
   };
 };
@@ -44,6 +45,16 @@ export type SnapshotInfo = {
   root: unknown;
 };
 
+type RawGraphDotInfo = {
+  world_dot: string;
+  logic_dot: string;
+};
+
+export type GraphDotInfo = {
+  worldDot: string;
+  logicDot: string;
+};
+
 export class NbtSimulationError extends Error {
   constructor(message: string, readonly trace: TraceEntry[], readonly snapshots: SnapshotInfo[]) {
     super(message);
@@ -75,6 +86,17 @@ function samePos(a: [number, number, number], b: [number, number, number]): bool
 
 export class NbtSimulation {
   private constructor(private readonly sim: WasmSimulator) {}
+
+  static async graphDot(nbtBytes: Uint8Array): Promise<GraphDotInfo> {
+    const wasm = await loadWasmModule();
+    await wasm.default(resolveAssetPath(wasmBinaryPath));
+    const graphDot = wasm.NbtSimulator.graph_dot(nbtBytes);
+
+    return {
+      worldDot: graphDot.world_dot,
+      logicDot: graphDot.logic_dot,
+    };
+  }
 
   static async create(nbtBytes: Uint8Array): Promise<NbtSimulation> {
     const wasm = await loadWasmModule();

--- a/tools/nbt-viewer/src/sim/NbtSimulation.ts
+++ b/tools/nbt-viewer/src/sim/NbtSimulation.ts
@@ -51,13 +51,17 @@ export class NbtSimulationError extends Error {
   }
 }
 
-const wasmModulePath = '/wasm/nbt-sim/nbt_sim_wasm.js';
-const wasmBinaryPath = '/wasm/nbt-sim/nbt_sim_wasm_bg.wasm';
+const wasmModulePath = 'wasm/nbt-sim/nbt_sim_wasm.js';
+const wasmBinaryPath = 'wasm/nbt-sim/nbt_sim_wasm_bg.wasm';
 
 let wasmModulePromise: Promise<WasmModule> | undefined;
 
+function resolveAssetPath(path: string): string {
+  return new URL(`${import.meta.env.BASE_URL}${path}`, window.location.origin).href;
+}
+
 function loadWasmModule(): Promise<WasmModule> {
-  wasmModulePromise ??= import(/* @vite-ignore */ new URL(wasmModulePath, window.location.origin).href) as Promise<WasmModule>;
+  wasmModulePromise ??= import(/* @vite-ignore */ resolveAssetPath(wasmModulePath)) as Promise<WasmModule>;
   return wasmModulePromise;
 }
 
@@ -74,7 +78,7 @@ export class NbtSimulation {
 
   static async create(nbtBytes: Uint8Array): Promise<NbtSimulation> {
     const wasm = await loadWasmModule();
-    await wasm.default(wasmBinaryPath);
+    await wasm.default(resolveAssetPath(wasmBinaryPath));
 
     try {
       return new NbtSimulation(new wasm.NbtSimulator(nbtBytes));

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -72,7 +72,7 @@ input {
   background: rgb(38 47 55 / 88%);
 }
 
-.file-button input {
+.hidden-file-input {
   display: none;
 }
 

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -95,8 +95,9 @@ input {
 }
 
 .switches-panel {
-  top: 58px;
+  top: 50%;
   right: 16px;
+  transform: translateY(-50%);
   width: min(320px, calc(100vw - 32px));
   max-height: min(38vh, 320px);
   overflow: hidden;
@@ -419,6 +420,7 @@ input {
   .switches-panel {
     top: 104px;
     right: 12px;
+    transform: none;
     width: calc(100vw - 24px);
     max-height: 28vh;
   }

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -94,7 +94,16 @@ input {
   overflow: hidden;
 }
 
-.files-panel summary {
+.switches-panel {
+  top: 58px;
+  right: 16px;
+  width: min(320px, calc(100vw - 32px));
+  max-height: min(38vh, 320px);
+  overflow: hidden;
+}
+
+.files-panel summary,
+.switches-panel summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -107,11 +116,13 @@ input {
   list-style: none;
 }
 
-.files-panel summary::-webkit-details-marker {
+.files-panel summary::-webkit-details-marker,
+.switches-panel summary::-webkit-details-marker {
   display: none;
 }
 
-.files-panel summary::before {
+.files-panel summary::before,
+.switches-panel summary::before {
   content: "+";
   display: inline-grid;
   place-items: center;
@@ -123,11 +134,13 @@ input {
   flex: 0 0 auto;
 }
 
-.files-panel[open] summary::before {
+.files-panel[open] summary::before,
+.switches-panel[open] summary::before {
   content: "-";
 }
 
-#files-count {
+#files-count,
+#switches-count {
   min-width: 0;
   overflow: hidden;
   color: #9ea9b3;
@@ -142,7 +155,15 @@ input {
   border-top: 1px solid rgb(154 164 173 / 18%);
 }
 
-.files-list.empty {
+.switches-list {
+  max-height: calc(min(38vh, 320px) - 38px);
+  overflow: auto;
+  padding: 6px;
+  border-top: 1px solid rgb(154 164 173 / 18%);
+}
+
+.files-list.empty,
+.switches-list.empty {
   display: grid;
   min-height: 120px;
   place-items: center;
@@ -152,7 +173,8 @@ input {
   text-align: center;
 }
 
-.file-entry {
+.file-entry,
+.switch-entry {
   display: flex;
   align-items: center;
   gap: 10px;
@@ -171,30 +193,35 @@ input {
   cursor: pointer;
 }
 
-.file-entry-name {
+.file-entry-name,
+.switch-entry-label {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.file-entry-size {
+.file-entry-size,
+.switch-entry-state {
   margin-left: auto;
   color: #9ea9b3;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
-.file-entry:hover {
+.file-entry:hover,
+.switch-entry:hover {
   background: rgb(255 255 255 / 7%);
 }
 
-.file-entry.selected {
+.file-entry.selected,
+.switch-entry.selected {
   background: rgb(211 50 50 / 24%);
   color: #fff;
 }
 
-.file-entry.selected .file-entry-size {
+.file-entry.selected .file-entry-size,
+.switch-entry.selected .switch-entry-state {
   color: #ffd0d0;
 }
 
@@ -387,6 +414,13 @@ input {
     top: 58px;
     left: 12px;
     width: calc(100vw - 24px);
+  }
+
+  .switches-panel {
+    top: 104px;
+    right: 12px;
+    width: calc(100vw - 24px);
+    max-height: 28vh;
   }
 
   .inspector-panel {

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -51,6 +51,13 @@ input {
   right: 16px;
   z-index: 4;
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+}
+
+.file-actions-row {
+  display: flex;
   gap: 8px;
 }
 
@@ -66,6 +73,10 @@ input {
   cursor: pointer;
   backdrop-filter: blur(14px);
   box-shadow: 0 10px 30px rgb(0 0 0 / 24%);
+}
+
+.graph-button {
+  width: 104px;
 }
 
 .file-button:hover {
@@ -405,6 +416,180 @@ input {
   display: none;
 }
 
+.graph-dialog {
+  width: min(1800px, calc(100vw - 12px));
+  height: min(1200px, calc(100vh - 12px));
+  padding: 0;
+  overflow: hidden;
+  border: 1px solid rgb(154 164 173 / 30%);
+  border-radius: 8px;
+  background: rgb(18 22 26 / 96%);
+  color: #e7ecef;
+  box-shadow: 0 24px 80px rgb(0 0 0 / 58%);
+}
+
+.graph-dialog::backdrop {
+  background: rgb(0 0 0 / 58%);
+}
+
+.graph-dialog-surface {
+  display: grid;
+  grid-template-rows: auto auto auto 1fr;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.graph-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 42px;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgb(154 164 173 / 18%);
+  font-size: 13px;
+}
+
+.graph-tabs {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px 12px;
+  border-bottom: 1px solid rgb(154 164 173 / 18%);
+}
+
+.graph-tab {
+  min-height: 28px;
+  padding: 4px 10px;
+  border: 1px solid rgb(154 164 173 / 30%);
+  border-radius: 4px;
+  background: rgb(22 27 31 / 82%);
+  color: #dce3e7;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.graph-tab:hover,
+.graph-tab.active {
+  background: rgb(211 50 50 / 26%);
+  color: #fff;
+}
+
+.graph-zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.graph-zoom-button,
+.graph-zoom-value {
+  height: 28px;
+  border: 1px solid rgb(154 164 173 / 30%);
+  border-radius: 4px;
+  background: rgb(22 27 31 / 82%);
+  color: #dce3e7;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.graph-zoom-button {
+  width: 30px;
+}
+
+.graph-zoom-value {
+  min-width: 54px;
+  padding: 0 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.graph-zoom-button:hover,
+.graph-zoom-value:hover {
+  background: rgb(38 47 55 / 88%);
+}
+
+.graph-zoom-button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
+.graph-status {
+  min-height: 30px;
+  padding: 8px 12px;
+  border-bottom: 1px solid rgb(154 164 173 / 18%);
+  color: #9ea9b3;
+  font-family: "Cascadia Mono", Consolas, monospace;
+  font-size: 12px;
+}
+
+.graph-viewer {
+  position: relative;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.graph-output {
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  background: #f7f9fb;
+  color: #111820;
+}
+
+.graph-output svg {
+  display: block;
+  max-width: none;
+  margin: 18px;
+}
+
+.graph-minimap {
+  position: absolute;
+  right: 14px;
+  bottom: 14px;
+  width: 220px;
+  height: 150px;
+  overflow: hidden;
+  border: 1px solid rgb(17 24 32 / 28%);
+  border-radius: 6px;
+  background: rgb(247 249 251 / 88%);
+  box-shadow: 0 12px 34px rgb(0 0 0 / 20%);
+  cursor: grab;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.graph-minimap:active {
+  cursor: grabbing;
+}
+
+.graph-minimap.hidden {
+  display: none;
+}
+
+.graph-minimap-content {
+  position: absolute;
+  inset: 8px;
+  overflow: hidden;
+}
+
+.graph-minimap-content svg {
+  display: block;
+  margin: 0;
+  transform-origin: top left;
+}
+
+.graph-minimap-viewport {
+  position: absolute;
+  left: 8px;
+  top: 8px;
+  min-width: 8px;
+  min-height: 8px;
+  border: 2px solid #d33232;
+  background: rgb(211 50 50 / 10%);
+}
+
 @media (max-width: 720px) {
   .floating-actions {
     top: 12px;
@@ -445,5 +630,12 @@ input {
 
   #trace-output {
     max-height: calc(28vh - 76px);
+  }
+
+  .graph-minimap {
+    width: 150px;
+    height: 104px;
+    right: 10px;
+    bottom: 10px;
   }
 }

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -72,7 +72,7 @@ input {
   background: rgb(38 47 55 / 88%);
 }
 
-.hidden-file-input {
+.file-button input {
   display: none;
 }
 

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -214,7 +214,7 @@ input {
   overflow: hidden;
 }
 
-.trace-panel summary {
+.trace-panel > summary {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -227,7 +227,8 @@ input {
   list-style: none;
 }
 
-.trace-panel summary::-webkit-details-marker {
+.trace-panel > summary::-webkit-details-marker,
+.trace-log summary::-webkit-details-marker {
   display: none;
 }
 
@@ -276,8 +277,37 @@ input {
   white-space: nowrap;
 }
 
+.trace-log {
+  border-top: 1px solid rgb(154 164 173 / 18%);
+}
+
+.trace-log summary {
+  min-height: 30px;
+  padding: 7px 12px;
+  color: #cbd4db;
+  cursor: pointer;
+  font-size: 12px;
+  list-style: none;
+}
+
+.trace-log summary::before {
+  content: "+";
+  display: inline-grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  margin-right: 8px;
+  border: 1px solid rgb(154 164 173 / 34%);
+  border-radius: 4px;
+  color: #cbd4db;
+}
+
+.trace-log[open] summary::before {
+  content: "-";
+}
+
 #trace-output {
-  max-height: calc(min(34vh, 300px) - 76px);
+  max-height: calc(min(34vh, 300px) - 106px);
   margin: 0;
   overflow: auto;
   padding: 10px 12px;

--- a/tools/nbt-viewer/src/vite-env.d.ts
+++ b/tools/nbt-viewer/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tools/nbt-viewer/vite.config.ts
+++ b/tools/nbt-viewer/vite.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: process.env.VITE_BASE_PATH ?? '/',
+});


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and publish the NBT viewer to Pages
- build the Rust WASM simulator before the Vite production build
- resolve WASM and mcmeta assets through the Vite base path for repository Pages

## Verification
- npm.cmd run build:wasm
- VITE_BASE_PATH=/redstone-compiler/ npm.cmd run build

## Notes
- The workflow publishes tools/nbt-viewer/dist to GitHub Pages.
- WASM files are generated during CI and included in the Pages artifact.
- The mcmeta cache is still generated/local and needs a deployable asset source before real block textures will render in CI-built Pages output.