### PR TITLE
Fix NBT viewer Pages asset preparation

### DIFF
--- a/.github/workflows/deploy-nbt-viewer.yml
+++ b/.github/workflows/deploy-nbt-viewer.yml
@@ -70,15 +70,7 @@ jobs:
         run: npm ci
 
       - name: Prepare Minecraft block assets
-        run: |
-          if [ -d "$MCMETA_SOURCE_DIR" ]; then
-            npm run prepare:mcmeta
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "::warning::Skipping mcmeta asset preparation because $MCMETA_SOURCE_DIR does not exist."
-          else
-            echo "::error::Missing mcmeta asset source at $MCMETA_SOURCE_DIR."
-            exit 1
-          fi
+        run: npm run prepare:mcmeta
         env:
           MCMETA_SOURCE_DIR: ${{ github.workspace }}/tools/nbt-viewer/public/mcmeta-source
 

--- a/tools/nbt-viewer/scripts/prepare-mcmeta-from-vscode-cache.mjs
+++ b/tools/nbt-viewer/scripts/prepare-mcmeta-from-vscode-cache.mjs
@@ -1,6 +1,9 @@
-import { copyFile, mkdir } from 'node:fs/promises';
+import { gunzipSync } from 'node:zlib';
+import { copyFile, mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+const MCMETA = 'https://raw.githubusercontent.com/misode/mcmeta';
 const version = process.argv[2] ?? '1.18.2';
 const sourceRoot = process.env.MCMETA_SOURCE_DIR ?? defaultSourceRoot();
 const targetRoot = join(process.cwd(), 'public', 'mcmeta');
@@ -8,18 +11,111 @@ const files = ['assets', 'atlas', 'blocks', 'uvmapping'];
 
 await mkdir(targetRoot, { recursive: true });
 
-for (const file of files) {
-  await copyFile(join(sourceRoot, `${version}-${file}`), join(targetRoot, `${version}-${file}`));
+if (sourceRoot && existsSync(sourceRoot)) {
+  await copyLocalCache();
+} else {
+  await downloadMcmeta();
 }
 
-await copyFile(join(sourceRoot, 'versions'), join(targetRoot, 'versions'));
-console.log(`Copied vscode-nbt mcmeta cache for ${version} to ${targetRoot}`);
+async function copyLocalCache() {
+  for (const file of files) {
+    await copyFile(join(sourceRoot, `${version}-${file}`), join(targetRoot, `${version}-${file}`));
+  }
+
+  await copyFile(join(sourceRoot, 'versions'), join(targetRoot, 'versions'));
+  console.log(`Copied vscode-nbt mcmeta cache for ${version} to ${targetRoot}`);
+}
+
+async function downloadMcmeta() {
+  console.log(`Downloading mcmeta assets for ${version} to ${targetRoot}`);
+
+  const [versions, blocks, atlas, uvmapping, assetsArchive] = await Promise.all([
+    fetchBytes(`${MCMETA}/summary/versions/data.min.json`),
+    fetchBytes(`${MCMETA}/${version}-summary/blocks/data.min.json`),
+    fetchBytes(`${MCMETA}/${version}-atlas/all/atlas.png`),
+    fetchBytes(`${MCMETA}/${version}-atlas/all/data.min.json`),
+    fetchBytes(`https://github.com/misode/mcmeta/tarball/${version}-assets-json`),
+  ]);
+
+  await Promise.all([
+    writeFile(join(targetRoot, 'versions'), versions),
+    writeFile(join(targetRoot, `${version}-blocks`), wrapJson('stringifiedBlocks', blocks)),
+    writeFile(join(targetRoot, `${version}-atlas`), atlas),
+    writeFile(join(targetRoot, `${version}-uvmapping`), wrapJson('stringifiedUvmapping', uvmapping)),
+    writeFile(join(targetRoot, `${version}-assets`), await buildAssetsJson(assetsArchive)),
+  ]);
+
+  console.log(`Downloaded mcmeta assets for ${version} to ${targetRoot}`);
+}
+
+async function fetchBytes(url) {
+  const response = await fetch(url, { redirect: 'follow' });
+  if (!response.ok) {
+    throw new Error(`Failed to download ${url}: ${response.status} ${response.statusText}`);
+  }
+
+  return Buffer.from(await response.arrayBuffer());
+}
+
+async function buildAssetsJson(archive) {
+  const entries = readTarGz(archive, path => {
+    return path.includes('/assets/minecraft/models/') || path.includes('/assets/minecraft/blockstates/');
+  });
+
+  const blockstates = filterJsonEntries(entries, 'blockstates');
+  const models = filterJsonEntries(entries, 'models');
+  return wrapJson('stringifiedAssets', Buffer.from(JSON.stringify({ blockstates, models })));
+}
+
+function filterJsonEntries(entries, type) {
+  const pattern = RegExp(`/assets/minecraft/${type}/([a-z0-9/_]+)\\.json$`);
+  return Object.fromEntries(
+    entries.flatMap(({ path, data }) => {
+      const match = path.match(pattern);
+      return match ? [[match[1], JSON.parse(data.toString('utf-8'))]] : [];
+    }),
+  );
+}
+
+function readTarGz(archive, filter) {
+  const buffer = gunzipSync(archive);
+  const entries = [];
+  let offset = 0;
+
+  while (offset + 512 <= buffer.length) {
+    const header = buffer.subarray(offset, offset + 512);
+    if (header.every(byte => byte === 0)) break;
+
+    const name = readTarString(header, 0, 100);
+    const prefix = readTarString(header, 345, 155);
+    const path = prefix ? `${prefix}/${name}` : name;
+    const size = Number.parseInt(readTarString(header, 124, 12).trim() || '0', 8);
+    const dataStart = offset + 512;
+    const dataEnd = dataStart + size;
+
+    if (filter(path)) {
+      entries.push({ path, data: buffer.subarray(dataStart, dataEnd) });
+    }
+
+    offset = dataStart + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function readTarString(buffer, start, length) {
+  const bytes = buffer.subarray(start, start + length);
+  const end = bytes.indexOf(0);
+  return bytes.subarray(0, end === -1 ? bytes.length : end).toString('utf-8');
+}
+
+function wrapJson(variableName, data) {
+  return Buffer.from(`const ${variableName} = \`${data.toString('utf-8')}\``);
+}
 
 function defaultSourceRoot() {
   const localAppData = process.env.LOCALAPPDATA;
-  if (!localAppData) {
-    throw new Error('LOCALAPPDATA is not set. Set MCMETA_SOURCE_DIR to a mcmeta cache directory.');
-  }
+  if (!localAppData) return undefined;
 
   return join(localAppData, 'vscode-nbt-nodejs', 'Cache', 'mcmeta');
 }


### PR DESCRIPTION
Fixes the Pages build failure after merging the NBT viewer deployment workflow.\n\nChanges:\n- Always run the mcmeta preparation step in CI.\n- Keep local vscode-nbt cache copying when available.\n- Fall back to downloading the same mcmeta assets from misode/mcmeta when the cache source is missing on GitHub runners.\n\nVerified locally:\n- npm.cmd run prepare:mcmeta with missing MCMETA_SOURCE_DIR\n- npm.cmd run build