### PR TITLE
Add bulk switch controls to NBT viewer

### DIFF
--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -91,6 +91,10 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
             <span>Switches</span>
             <span id="switches-count">No switches</span>
           </summary>
+          <div id="switches-actions" class="switches-actions hidden">
+            <button id="switches-all-on" type="button">All On</button>
+            <button id="switches-all-off" type="button">All Off</button>
+          </div>
           <div id="switches-list" class="switches-list empty">Open an NBT file to control switches.</div>
         </details>
         <details id="files-panel" class="floating-panel files-panel">
@@ -172,6 +176,9 @@ const traceCycleLabel = document.querySelector<HTMLElement>('#trace-cycle-label'
 const tracePrevButton = document.querySelector<HTMLButtonElement>('#trace-prev')!;
 const traceNextButton = document.querySelector<HTMLButtonElement>('#trace-next')!;
 const switchesPanel = document.querySelector<HTMLDetailsElement>('#switches-panel')!;
+const switchesActions = document.querySelector<HTMLElement>('#switches-actions')!;
+const switchesAllOnButton = document.querySelector<HTMLButtonElement>('#switches-all-on')!;
+const switchesAllOffButton = document.querySelector<HTMLButtonElement>('#switches-all-off')!;
 const switchesList = document.querySelector<HTMLElement>('#switches-list')!;
 const switchesCount = document.querySelector<HTMLElement>('#switches-count')!;
 const openGraphsButton = document.querySelector<HTMLButtonElement>('#open-graphs')!;
@@ -225,6 +232,18 @@ folderInput.addEventListener('change', () => {
 
 toggleSwitchButton.addEventListener('click', () => {
   void toggleSelectedSwitch().catch(error => {
+    renderSimulationError(error);
+  });
+});
+
+switchesAllOnButton.addEventListener('click', () => {
+  void setAllSwitches(true).catch(error => {
+    renderSimulationError(error);
+  });
+});
+
+switchesAllOffButton.addEventListener('click', () => {
+  void setAllSwitches(false).catch(error => {
     renderSimulationError(error);
   });
 });
@@ -487,16 +506,47 @@ async function toggleSwitchBlock(block: StructureBlock): Promise<void> {
   const nextRoot = simulation.toggleSwitch(block);
   if (!nextRoot) return;
 
+  await applySimulatedRoot(simulation, nextRoot, baseRoot, selectedPos);
+}
+
+async function setAllSwitches(isOn: boolean): Promise<void> {
+  if (!currentNbtBytes) return;
+
+  const structure = toStructureModel(currentRoot);
+  const switches = structure?.blocks.filter(block => block.palette.name === 'minecraft:lever') ?? [];
+  if (switches.length === 0) return;
+
+  simulation ??= await NbtSimulation.create(currentNbtBytes);
+
+  const selectedPos = selectedBlock?.pos;
+  const baseRoot = currentRoot;
+  let nextRoot: unknown | undefined;
+
+  for (const block of switches) {
+    nextRoot = simulation.setSwitch(block, isOn) ?? nextRoot;
+  }
+
+  if (!nextRoot) return;
+
+  await applySimulatedRoot(simulation, nextRoot, baseRoot, selectedPos);
+}
+
+async function applySimulatedRoot(
+  activeSimulation: NbtSimulation,
+  nextRoot: unknown,
+  baseRoot: unknown,
+  selectedPos: StructureBlock['pos'] | undefined,
+): Promise<void> {
   currentRoot = mergeSimulatedState(currentRoot, nextRoot);
   const structure = toStructureModel(currentRoot);
   if (!structure) throw new Error('Simulator returned a structure that the viewer could not render.');
 
   await viewer.setStructure(structure, { preserveSelection: true, preserveView: true });
-  const nextSelectedBlock = structure.blocks.find(block => samePos(block.pos, selectedPos));
+  const nextSelectedBlock = selectedPos ? structure.blocks.find(block => samePos(block.pos, selectedPos)) : undefined;
   viewer.setSelectedBlock(nextSelectedBlock);
   renderSelection(nextSelectedBlock);
   renderSwitches(structure);
-  renderTrace(simulation.trace(), simulation.snapshots(), baseRoot, { animateTo: 'last' });
+  renderTrace(activeSimulation.trace(), activeSimulation.snapshots(), baseRoot, { animateTo: 'last' });
 }
 
 dropZone.addEventListener('dragover', event => {
@@ -812,6 +862,7 @@ function renderSwitches(structure?: StructureModel): void {
   switchesList.replaceChildren();
   const switches = structure?.blocks.filter(block => block.palette.name === 'minecraft:lever') ?? [];
   switchesCount.textContent = switches.length === 0 ? 'No switches' : `${switches.length} switches`;
+  switchesActions.classList.toggle('hidden', switches.length === 0);
 
   if (switches.length === 0) {
     switchesPanel.open = !structure;

--- a/tools/nbt-viewer/src/sim/NbtSimulation.ts
+++ b/tools/nbt-viewer/src/sim/NbtSimulation.ts
@@ -133,9 +133,16 @@ export class NbtSimulation {
     const current = this.getSwitch(block);
     if (!current) return undefined;
 
+    return this.setSwitch(block, !current.is_on);
+  }
+
+  setSwitch(block: StructureBlock, isOn: boolean): unknown | undefined {
+    const current = this.getSwitch(block);
+    if (!current || current.is_on === isOn) return undefined;
+
     const [x, y, z] = current.pos;
     try {
-      return this.sim.toggle_switch(x, y, z, !current.is_on);
+      return this.sim.toggle_switch(x, y, z, isOn);
     } catch (error) {
       throw new NbtSimulationError(getErrorMessage(error), this.trace(), this.snapshots());
     }

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -169,10 +169,41 @@ input {
 }
 
 .switches-list {
-  max-height: calc(min(38vh, 320px) - 38px);
+  max-height: calc(min(38vh, 320px) - 79px);
   overflow: auto;
   padding: 6px;
   border-top: 1px solid rgb(154 164 173 / 18%);
+}
+
+.switches-actions.hidden + .switches-list {
+  max-height: calc(min(38vh, 320px) - 38px);
+}
+
+.switches-actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+  padding: 6px;
+  border-top: 1px solid rgb(154 164 173 / 18%);
+}
+
+.switches-actions button {
+  min-width: 0;
+  min-height: 28px;
+  border: 1px solid rgb(154 164 173 / 24%);
+  border-radius: 4px;
+  background: rgb(255 255 255 / 7%);
+  color: #dce3e7;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.switches-actions button:hover {
+  background: rgb(255 255 255 / 12%);
+}
+
+.switches-actions.hidden {
+  display: none;
 }
 
 .files-list.empty,
@@ -609,6 +640,14 @@ input {
     transform: none;
     width: calc(100vw - 24px);
     max-height: 28vh;
+  }
+
+  .switches-list {
+    max-height: calc(28vh - 79px);
+  }
+
+  .switches-actions.hidden + .switches-list {
+    max-height: calc(28vh - 38px);
   }
 
   .inspector-panel {


### PR DESCRIPTION
## Summary
- Add All On / All Off controls to the NBT viewer switches panel
- Reuse simulator switch state updates for bulk switch changes
- Adjust switch list scroll height so the final switch remains reachable on desktop and mobile

## Verification
- npm.cmd run build