### PR TITLE
Improve NBT viewer graph selection workflows

### DIFF
--- a/crates/nbt-sim-wasm/src/lib.rs
+++ b/crates/nbt-sim-wasm/src/lib.rs
@@ -1,10 +1,14 @@
+use std::collections::HashSet;
+
 use redstone_compiler::graph::graphviz::ToGraphvizGraph;
 use redstone_compiler::graph::world::WorldGraphBuilder;
+use redstone_compiler::graph::{GraphNodeId, GraphNodeKind};
 use redstone_compiler::nbt::{NBTRoot, ToNBT};
 use redstone_compiler::transform::world_to_logic::WorldToLogicTransformer;
 use redstone_compiler::world::block::BlockKind;
-use redstone_compiler::world::position::Position;
+use redstone_compiler::world::position::{DimSize, Position};
 use redstone_compiler::world::simulator::{SimulationSnapshot, SimulationTraceEntry, Simulator};
+use redstone_compiler::world::{World, World3D};
 use serde::Serialize;
 use wasm_bindgen::prelude::*;
 
@@ -119,6 +123,72 @@ impl NbtSimulator {
         serde_wasm_bindgen::to_value(&graph_dot).map_err(to_js_error)
     }
 
+    pub fn selected_graph_dot(
+        nbt_bytes: &[u8],
+        folded: bool,
+        node_ids: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let selected_node_ids: Vec<GraphNodeId> =
+            serde_wasm_bindgen::from_value(node_ids).map_err(to_js_error)?;
+        let selected_node_ids = selected_node_ids.into_iter().collect::<HashSet<_>>();
+        let nbt = NBTRoot::from_nbt_bytes(nbt_bytes).map_err(to_js_error)?;
+        let world = nbt.to_world();
+        let raw_world_graph = WorldGraphBuilder::new(&world).build();
+        let source_world_graph = if folded {
+            let transformer =
+                WorldToLogicTransformer::new(raw_world_graph, true).map_err(to_js_error)?;
+            transformer.world_graph().clone()
+        } else {
+            raw_world_graph
+        };
+
+        let selected_world_graph =
+            source_world_graph.extract_subgraph_by_node_ids(&selected_node_ids);
+        let transformer = WorldToLogicTransformer::new(selected_world_graph.clone(), true)
+            .map_err(to_js_error)?;
+        let folded_world_dot = transformer.world_graph().to_graphviz();
+        let folded_world_dot_without_tags = transformer.world_graph().to_graphviz_without_tags();
+        let logic_graph = transformer.transform().map_err(to_js_error)?;
+        let graph_dot = GraphDotInfo {
+            raw_world_dot: selected_world_graph.to_graphviz(),
+            raw_world_dot_without_tags: selected_world_graph.to_graphviz_without_tags(),
+            folded_world_dot,
+            folded_world_dot_without_tags,
+            logic_dot: logic_graph.to_graphviz(),
+            logic_dot_without_tags: logic_graph.to_graphviz_without_tags(),
+        };
+
+        serde_wasm_bindgen::to_value(&graph_dot).map_err(to_js_error)
+    }
+
+    pub fn selected_nbt(
+        nbt_bytes: &[u8],
+        folded: bool,
+        node_ids: JsValue,
+    ) -> Result<JsValue, JsValue> {
+        let selected_node_ids: Vec<GraphNodeId> =
+            serde_wasm_bindgen::from_value(node_ids).map_err(to_js_error)?;
+        let selected_node_ids = selected_node_ids.into_iter().collect::<HashSet<_>>();
+        let nbt = NBTRoot::from_nbt_bytes(nbt_bytes).map_err(to_js_error)?;
+        let world = nbt.to_world();
+        let raw_world_graph = WorldGraphBuilder::new(&world).build();
+        let source_world_graph = if folded {
+            let transformer =
+                WorldToLogicTransformer::new(raw_world_graph.clone(), true).map_err(to_js_error)?;
+            transformer.world_graph().clone()
+        } else {
+            raw_world_graph.clone()
+        };
+        let selected_world = selected_world_from_graph(
+            &world,
+            &raw_world_graph,
+            &source_world_graph,
+            &selected_node_ids,
+        );
+
+        serde_wasm_bindgen::to_value(&selected_world.to_nbt()).map_err(to_js_error)
+    }
+
     pub fn switches(&self) -> Result<JsValue, JsValue> {
         let switches = self
             .sim
@@ -195,5 +265,75 @@ fn snapshots_to_info(snapshots: &[SimulationSnapshot]) -> Vec<SnapshotInfo> {
             cycle: snapshot.cycle,
             root: snapshot.world.to_nbt(),
         })
+        .collect()
+}
+
+fn selected_world_from_graph(
+    world: &World,
+    raw_world_graph: &redstone_compiler::graph::world::WorldGraph,
+    source_world_graph: &redstone_compiler::graph::world::WorldGraph,
+    selected_node_ids: &HashSet<GraphNodeId>,
+) -> World3D {
+    let mut positions = HashSet::new();
+    for node_id in selected_node_ids {
+        if let Some(position) = source_world_graph.positions.get(node_id) {
+            positions.insert(*position);
+        }
+
+        let Some(node) = source_world_graph.graph.find_node_by_id(*node_id) else {
+            continue;
+        };
+        if !matches!(node.kind, GraphNodeKind::Sequential(_)) && !node.tag.starts_with("Folded ") {
+            continue;
+        }
+        for source_node_id in source_node_ids_from_tag(&node.tag) {
+            if let Some(position) = raw_world_graph.positions.get(&source_node_id) {
+                positions.insert(*position);
+            }
+        }
+    }
+
+    compact_world_from_positions(world, &positions)
+}
+
+fn compact_world_from_positions(world: &World, positions: &HashSet<Position>) -> World3D {
+    if positions.is_empty() {
+        return World3D::new(DimSize(1, 1, 1));
+    }
+
+    let min_x = positions.iter().map(|position| position.0).min().unwrap();
+    let min_y = positions.iter().map(|position| position.1).min().unwrap();
+    let min_z = positions.iter().map(|position| position.2).min().unwrap();
+    let max_x = positions.iter().map(|position| position.0).max().unwrap();
+    let max_y = positions.iter().map(|position| position.1).max().unwrap();
+    let max_z = positions.iter().map(|position| position.2).max().unwrap();
+    let mut selected_world = World3D::new(DimSize(
+        max_x - min_x + 1,
+        max_y - min_y + 1,
+        max_z - min_z + 1,
+    ));
+
+    for (position, block) in &world.blocks {
+        if !positions.contains(position) {
+            continue;
+        }
+        selected_world[Position(position.0 - min_x, position.1 - min_y, position.2 - min_z)] =
+            *block;
+    }
+
+    selected_world
+}
+
+fn source_node_ids_from_tag(tag: &str) -> Vec<GraphNodeId> {
+    let Some(start) = tag.rfind('[') else {
+        return Vec::new();
+    };
+    let Some(end) = tag[start..].find(']') else {
+        return Vec::new();
+    };
+
+    tag[start + 1..start + end]
+        .split(',')
+        .filter_map(|value| value.trim().parse().ok())
         .collect()
 }

--- a/crates/nbt-sim-wasm/src/lib.rs
+++ b/crates/nbt-sim-wasm/src/lib.rs
@@ -1,9 +1,10 @@
 use std::collections::HashSet;
 
 use redstone_compiler::graph::graphviz::ToGraphvizGraph;
-use redstone_compiler::graph::world::WorldGraphBuilder;
+use redstone_compiler::graph::world::{WorldGraph, WorldGraphBuilder};
 use redstone_compiler::graph::{GraphNodeId, GraphNodeKind};
 use redstone_compiler::nbt::{NBTRoot, ToNBT};
+use redstone_compiler::transform::place_and_route::place_bound::{PlaceBound, PropagateType};
 use redstone_compiler::transform::world_to_logic::WorldToLogicTransformer;
 use redstone_compiler::world::block::{Block, BlockKind, Direction};
 use redstone_compiler::world::position::{DimSize, Position};
@@ -275,6 +276,7 @@ fn selected_world_from_graph(
     selected_node_ids: &HashSet<GraphNodeId>,
 ) -> World3D {
     let mut positions = HashSet::new();
+    let mut raw_node_ids = HashSet::new();
     for node_id in selected_node_ids {
         if let Some(position) = source_world_graph.positions.get(node_id) {
             positions.insert(*position);
@@ -284,17 +286,88 @@ fn selected_world_from_graph(
             continue;
         };
         if !matches!(node.kind, GraphNodeKind::Sequential(_)) && !node.tag.starts_with("Folded ") {
+            raw_node_ids.insert(*node_id);
             continue;
         }
         for source_node_id in source_node_ids_from_tag(&node.tag) {
             if let Some(position) = raw_world_graph.positions.get(&source_node_id) {
                 positions.insert(*position);
+                raw_node_ids.insert(source_node_id);
             }
         }
     }
 
+    add_edge_routing_blocks(world, raw_world_graph, &raw_node_ids, &mut positions);
     add_attached_blocks(world, &mut positions);
     compact_world_from_positions(world, &positions)
+}
+
+fn add_edge_routing_blocks(
+    world: &World,
+    raw_world_graph: &WorldGraph,
+    raw_node_ids: &HashSet<GraphNodeId>,
+    positions: &mut HashSet<Position>,
+) {
+    let world3d = World3D::from(world);
+    let route_positions = raw_node_ids
+        .iter()
+        .flat_map(|source_node_id| {
+            let Some(source_node) = raw_world_graph.graph.find_node_by_id(*source_node_id) else {
+                return Vec::new();
+            };
+            let Some(source_position) = raw_world_graph.positions.get(source_node_id) else {
+                return Vec::new();
+            };
+            let source_outputs = source_node
+                .outputs
+                .iter()
+                .copied()
+                .filter(|target_node_id| raw_node_ids.contains(target_node_id))
+                .collect::<Vec<_>>();
+
+            source_outputs
+                .into_iter()
+                .filter_map(|target_node_id| raw_world_graph.positions.get(&target_node_id))
+                .flat_map(|target_position| {
+                    edge_routing_positions(
+                        *source_position,
+                        *target_position,
+                        &source_node.kind,
+                        &world3d,
+                    )
+                })
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    positions.extend(route_positions);
+}
+
+fn edge_routing_positions(
+    source_position: Position,
+    target_position: Position,
+    source_kind: &GraphNodeKind,
+    world: &World3D,
+) -> Vec<Position> {
+    let GraphNodeKind::Block(source_block) = source_kind else {
+        return Vec::new();
+    };
+
+    PlaceBound(PropagateType::Soft, source_position, source_block.direction)
+        .propagation_bound(&source_block.kind, Some(world))
+        .into_iter()
+        .filter(|bound| world.size.bound_on(bound.position()))
+        .filter(|bound| {
+            bound
+                .propagate_to(world)
+                .into_iter()
+                .any(|(_, position)| position == target_position)
+        })
+        .map(|bound| bound.position())
+        .filter(|position| *position != source_position && *position != target_position)
+        .filter(|position| world.size.bound_on(*position))
+        .filter(|position| !world[*position].kind.is_air())
+        .collect()
 }
 
 fn add_attached_blocks(world: &World, positions: &mut HashSet<Position>) {

--- a/crates/nbt-sim-wasm/src/lib.rs
+++ b/crates/nbt-sim-wasm/src/lib.rs
@@ -5,7 +5,7 @@ use redstone_compiler::graph::world::WorldGraphBuilder;
 use redstone_compiler::graph::{GraphNodeId, GraphNodeKind};
 use redstone_compiler::nbt::{NBTRoot, ToNBT};
 use redstone_compiler::transform::world_to_logic::WorldToLogicTransformer;
-use redstone_compiler::world::block::BlockKind;
+use redstone_compiler::world::block::{Block, BlockKind, Direction};
 use redstone_compiler::world::position::{DimSize, Position};
 use redstone_compiler::world::simulator::{SimulationSnapshot, SimulationTraceEntry, Simulator};
 use redstone_compiler::world::{World, World3D};
@@ -293,7 +293,46 @@ fn selected_world_from_graph(
         }
     }
 
+    add_attached_blocks(world, &mut positions);
     compact_world_from_positions(world, &positions)
+}
+
+fn add_attached_blocks(world: &World, positions: &mut HashSet<Position>) {
+    let world3d = World3D::from(world);
+    let attached_positions = positions
+        .iter()
+        .filter_map(|position| {
+            let block = world.blocks.iter().find_map(|(block_position, block)| {
+                (block_position == position).then_some(block)
+            })?;
+            attached_block_position(*position, *block)
+        })
+        .filter(|position| world3d.size.bound_on(*position))
+        .filter(|position| !world3d[*position].kind.is_air())
+        .collect::<Vec<_>>();
+
+    positions.extend(attached_positions);
+}
+
+fn attached_block_position(position: Position, block: Block) -> Option<Position> {
+    match block.kind {
+        BlockKind::Redstone { .. } | BlockKind::Repeater { .. } => position.down(),
+        BlockKind::Switch { .. } | BlockKind::Torch { .. } => {
+            attached_direction(position, block.direction)
+        }
+        BlockKind::Air
+        | BlockKind::Cobble { .. }
+        | BlockKind::RedstoneBlock
+        | BlockKind::Piston { .. } => None,
+    }
+}
+
+fn attached_direction(position: Position, direction: Direction) -> Option<Position> {
+    if direction == Direction::None {
+        return None;
+    }
+
+    position.walk(direction)
 }
 
 fn compact_world_from_positions(world: &World, positions: &HashSet<Position>) -> World3D {

--- a/crates/nbt-sim-wasm/src/lib.rs
+++ b/crates/nbt-sim-wasm/src/lib.rs
@@ -1,7 +1,7 @@
 use redstone_compiler::graph::graphviz::ToGraphvizGraph;
 use redstone_compiler::graph::world::WorldGraphBuilder;
 use redstone_compiler::nbt::{NBTRoot, ToNBT};
-use redstone_compiler::transform::place_and_route::utils::world_to_logic;
+use redstone_compiler::transform::world_to_logic::WorldToLogicTransformer;
 use redstone_compiler::world::block::BlockKind;
 use redstone_compiler::world::position::Position;
 use redstone_compiler::world::simulator::{SimulationSnapshot, SimulationTraceEntry, Simulator};
@@ -34,8 +34,12 @@ struct SnapshotInfo {
 
 #[derive(Serialize)]
 struct GraphDotInfo {
-    world_dot: String,
+    raw_world_dot: String,
+    raw_world_dot_without_tags: String,
+    folded_world_dot: String,
+    folded_world_dot_without_tags: String,
     logic_dot: String,
+    logic_dot_without_tags: String,
 }
 
 #[wasm_bindgen]
@@ -97,11 +101,19 @@ impl NbtSimulator {
     pub fn graph_dot(nbt_bytes: &[u8]) -> Result<JsValue, JsValue> {
         let nbt = NBTRoot::from_nbt_bytes(nbt_bytes).map_err(to_js_error)?;
         let world = nbt.to_world();
-        let world_graph = WorldGraphBuilder::new(&world).build();
-        let logic_graph = world_to_logic(&world).map_err(to_js_error)?;
+        let raw_world_graph = WorldGraphBuilder::new(&world).build();
+        let transformer =
+            WorldToLogicTransformer::new(raw_world_graph.clone(), true).map_err(to_js_error)?;
+        let folded_world_dot = transformer.world_graph().to_graphviz();
+        let folded_world_dot_without_tags = transformer.world_graph().to_graphviz_without_tags();
+        let logic_graph = transformer.transform().map_err(to_js_error)?;
         let graph_dot = GraphDotInfo {
-            world_dot: world_graph.to_graphviz(),
+            raw_world_dot: raw_world_graph.to_graphviz(),
+            raw_world_dot_without_tags: raw_world_graph.to_graphviz_without_tags(),
+            folded_world_dot,
+            folded_world_dot_without_tags,
             logic_dot: logic_graph.to_graphviz(),
+            logic_dot_without_tags: logic_graph.to_graphviz_without_tags(),
         };
 
         serde_wasm_bindgen::to_value(&graph_dot).map_err(to_js_error)

--- a/src/graph/graphviz.rs
+++ b/src/graph/graphviz.rs
@@ -9,7 +9,6 @@ use super::world::WorldGraph;
 use super::{Graph, GraphNode, GraphNodeId, SubGraph};
 use crate::graph::module::GraphModulePortTarget;
 
-#[derive(Default)]
 pub struct GraphvizBuilder<'a> {
     graph: Option<&'a Graph>,
     module: Option<&'a GraphModule>,
@@ -17,8 +16,25 @@ pub struct GraphvizBuilder<'a> {
     clusters: Option<Vec<(String, Vec<GraphNodeId>)>>,
     show_node_id: bool,
     table_style: bool,
+    show_tags: bool,
     named_inputs: Option<HashMap<(GraphNodeId, GraphNodeId), String>>,
     subname: Option<HashMap<GraphNodeId, String>>,
+}
+
+impl<'a> Default for GraphvizBuilder<'a> {
+    fn default() -> Self {
+        Self {
+            graph: None,
+            module: None,
+            depth: None,
+            clusters: None,
+            show_node_id: false,
+            table_style: false,
+            show_tags: true,
+            named_inputs: None,
+            subname: None,
+        }
+    }
 }
 
 impl<'a> GraphvizBuilder<'a> {
@@ -62,6 +78,11 @@ impl<'a> GraphvizBuilder<'a> {
 
     pub fn with_show_node_id(&mut self) -> &mut Self {
         self.show_node_id = true;
+        self
+    }
+
+    pub fn without_tags(&mut self) -> &mut Self {
+        self.show_tags = false;
         self
     }
 
@@ -168,12 +189,23 @@ digraph {graph_name} {{
         };
 
         if !self.table_style {
-            if node.tag.is_empty() {
+            if node.tag.is_empty() || !self.show_tags {
                 format!("    node{} [label=\"{}\"]", node.id, name)
             } else {
                 format!("    node{} [label=\"{} | {}\"]", node.id, name, node.tag)
             }
         } else {
+            let colspan = node.inputs.len().max(1);
+            let tag = if node.tag.is_empty() || !self.show_tags {
+                String::new()
+            } else {
+                format!(
+                    r##"<TR><TD COLSPAN="{}" BGCOLOR="#F6F6F6">
+                <FONT POINT-SIZE="10" COLOR="#666666">{}</FONT>
+            </TD></TR>"##,
+                    colspan, node.tag
+                )
+            };
             format!(
                 r#"    node{} [label=<
         <TABLE BORDER="0" CELLBORDER="1" CELLSPACING="0">
@@ -181,12 +213,10 @@ digraph {graph_name} {{
             <TR><TD COLSPAN="{}" PORT="out">
                 {}
             </TD></TR>
+            {}
         </TABLE>
     >]"#,
-                node.id,
-                inputs,
-                node.inputs.len(),
-                name
+                node.id, inputs, colspan, name, tag
             )
         }
     }
@@ -294,6 +324,8 @@ digraph {graph_name} {{
 pub trait ToGraphvizGraph {
     fn to_graphviz(&self) -> String;
 
+    fn to_graphviz_without_tags(&self) -> String;
+
     fn to_graphviz_with_clusters(&self, clusters: &[SubGraph]) -> String;
 }
 
@@ -301,6 +333,13 @@ impl ToGraphvizGraph for Graph {
     fn to_graphviz(&self) -> String {
         GraphvizBuilder::default()
             .with_graph(self)
+            .build("DefaultGraph")
+    }
+
+    fn to_graphviz_without_tags(&self) -> String {
+        GraphvizBuilder::default()
+            .with_graph(self)
+            .without_tags()
             .build("DefaultGraph")
     }
 
@@ -322,6 +361,13 @@ impl ToGraphvizGraph for LogicGraph {
     fn to_graphviz(&self) -> String {
         GraphvizBuilder::default()
             .with_graph(&self.graph)
+            .build("LogicGraph")
+    }
+
+    fn to_graphviz_without_tags(&self) -> String {
+        GraphvizBuilder::default()
+            .with_graph(&self.graph)
+            .without_tags()
             .build("LogicGraph")
     }
 
@@ -357,6 +403,24 @@ impl ToGraphvizGraph for WorldGraph {
             .build("WorldGraph")
     }
 
+    fn to_graphviz_without_tags(&self) -> String {
+        let mut subnames = HashMap::new();
+        subnames.extend(
+            self.positions
+                .iter()
+                .map(|(id, pos)| (*id, format!("{pos:?}"))),
+        );
+        subnames.extend(self.routings.iter().map(|id| (*id, "Routings".to_string())));
+
+        GraphvizBuilder::default()
+            .with_graph(&self.graph)
+            .with_table()
+            .with_show_node_id()
+            .with_subname(subnames)
+            .without_tags()
+            .build("WorldGraph")
+    }
+
     fn to_graphviz_with_clusters(&self, clusters: &[SubGraph]) -> String {
         GraphvizBuilder::default()
             .with_graph(&self.graph)
@@ -375,6 +439,20 @@ impl ToGraphvizGraph for GraphWithSubGraphs {
     fn to_graphviz(&self) -> String {
         GraphvizBuilder::default()
             .with_graph(&self.0)
+            .with_cluster(
+                self.1
+                    .iter()
+                    .enumerate()
+                    .map(|(index, g)| (format!("Cluster {}", index), g.clone()))
+                    .collect_vec(),
+            )
+            .build("LogicGraph")
+    }
+
+    fn to_graphviz_without_tags(&self) -> String {
+        GraphvizBuilder::default()
+            .with_graph(&self.0)
+            .without_tags()
             .with_cluster(
                 self.1
                     .iter()
@@ -412,6 +490,13 @@ impl ToGraphvizGraph for ClusteredGraph {
             .build("ClusteredGraph")
     }
 
+    fn to_graphviz_without_tags(&self) -> String {
+        GraphvizBuilder::default()
+            .with_graph(&self.graph)
+            .without_tags()
+            .build("ClusteredGraph")
+    }
+
     fn to_graphviz_with_clusters(&self, _: &[SubGraph]) -> String {
         unimplemented!()
     }
@@ -426,5 +511,51 @@ impl ToGraphvizModule for GraphModule {
         GraphvizBuilder::default()
             .with_module(self)
             .build("GraphModule")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::{Graph, GraphNode, GraphNodeKind};
+
+    #[test]
+    fn table_graphviz_shows_node_tags() {
+        let graph = Graph {
+            nodes: vec![GraphNode {
+                id: 0,
+                kind: GraphNodeKind::None,
+                tag: "Folded RS latch feedback SCC [1, 2, 3, 4]".to_owned(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let dot = GraphvizBuilder::default()
+            .with_graph(&graph)
+            .with_table()
+            .build("TaggedGraph");
+
+        assert!(dot.contains("Folded RS latch feedback SCC"));
+    }
+
+    #[test]
+    fn graphviz_can_hide_node_tags() {
+        let graph = Graph {
+            nodes: vec![GraphNode {
+                id: 0,
+                kind: GraphNodeKind::None,
+                tag: "debug source tag".to_owned(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let dot = GraphvizBuilder::default()
+            .with_graph(&graph)
+            .without_tags()
+            .build("TaggedGraph");
+
+        assert!(!dot.contains("debug source tag"));
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -225,6 +225,27 @@ impl Graph {
         components
     }
 
+    pub fn external_edges(&self, nodes: &HashSet<GraphNodeId>, incoming: bool) -> Vec<GraphNodeId> {
+        let mut edges = nodes
+            .iter()
+            .flat_map(|node_id| {
+                let node = self.find_node_by_id(*node_id).into_iter();
+                node.flat_map(move |node| {
+                    if incoming {
+                        node.inputs.iter()
+                    } else {
+                        node.outputs.iter()
+                    }
+                })
+            })
+            .filter(|node_id| !nodes.contains(node_id))
+            .copied()
+            .collect::<Vec<_>>();
+        edges.sort();
+        edges.dedup();
+        edges
+    }
+
     pub fn dominators(
         &self,
         target_root: GraphNodeId,
@@ -611,6 +632,52 @@ impl Graph {
         };
 
         self.nodes.remove(index);
+    }
+
+    pub fn replace_nodes_with(
+        &mut self,
+        removed_nodes: &HashSet<GraphNodeId>,
+        kind: GraphNodeKind,
+        inputs: Vec<GraphNodeId>,
+        outputs: Vec<GraphNodeId>,
+        tag: String,
+    ) -> GraphNodeId {
+        let replacement_id = self.max_node_id().unwrap_or(0) + 1;
+
+        for input in &inputs {
+            if let Some(node) = self.find_node_by_id_mut(*input) {
+                node.outputs.retain(|id| !removed_nodes.contains(id));
+                if !node.outputs.contains(&replacement_id) {
+                    node.outputs.push(replacement_id);
+                }
+            }
+        }
+        for output in &outputs {
+            if let Some(node) = self.find_node_by_id_mut(*output) {
+                node.inputs.retain(|id| !removed_nodes.contains(id));
+                if !node.inputs.contains(&replacement_id) {
+                    node.inputs.push(replacement_id);
+                }
+            }
+        }
+        for node_id in removed_nodes {
+            self.remove_by_node_id_lazy(*node_id);
+        }
+
+        self.nodes.push(GraphNode {
+            id: replacement_id,
+            kind,
+            inputs,
+            outputs,
+            tag,
+        });
+        self.nodes.sort_by_key(|node| node.id);
+        self.build_inputs();
+        self.build_outputs();
+        self.build_producers();
+        self.build_consumers();
+
+        replacement_id
     }
 
     // 노드 삭제하고 삭제한 노드의 Input Output끼리 연결함

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -838,6 +838,31 @@ impl Graph {
         SubGraphWithGraph::from(self, nodes)
     }
 
+    pub fn extract_graph_by_node_ids(&self, node_ids: &HashSet<GraphNodeId>) -> Self {
+        let mut nodes = self
+            .nodes
+            .iter()
+            .filter(|node| node_ids.contains(&node.id))
+            .cloned()
+            .collect_vec();
+
+        for node in &mut nodes {
+            node.inputs.retain(|input| node_ids.contains(input));
+            node.outputs.retain(|output| node_ids.contains(output));
+        }
+        nodes.sort_by_key(|node| node.id);
+
+        let mut graph = Self {
+            nodes,
+            ..Default::default()
+        };
+        graph.build_inputs();
+        graph.build_outputs();
+        graph.build_producers();
+        graph.build_consumers();
+        graph
+    }
+
     pub fn split_with_outputs(&self) -> Vec<SubGraphWithGraph> {
         self.outputs()
             .iter()
@@ -1197,6 +1222,56 @@ mod tests {
         assert_eq!(graph.find_node_by_id(0).unwrap().outputs, vec![3]);
         assert_eq!(graph.find_node_by_id(1).unwrap().outputs, vec![3]);
         assert_eq!(graph.find_node_by_id(2).unwrap().outputs, vec![3]);
+    }
+
+    #[test]
+    fn extract_graph_by_node_ids_keeps_only_internal_edges() {
+        let mut graph = Graph {
+            nodes: vec![
+                GraphNode {
+                    id: 0,
+                    outputs: vec![2],
+                    ..Default::default()
+                },
+                GraphNode {
+                    id: 1,
+                    outputs: vec![2],
+                    ..Default::default()
+                },
+                GraphNode {
+                    id: 2,
+                    inputs: vec![0, 1],
+                    outputs: vec![3, 4],
+                    ..Default::default()
+                },
+                GraphNode {
+                    id: 3,
+                    inputs: vec![2],
+                    ..Default::default()
+                },
+                GraphNode {
+                    id: 4,
+                    inputs: vec![2],
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        };
+        graph.build_producers();
+        graph.build_consumers();
+
+        let selected = HashSet::from([1, 2, 3]);
+        let subgraph = graph.extract_graph_by_node_ids(&selected);
+
+        assert_eq!(
+            subgraph.nodes.iter().map(|node| node.id).collect_vec(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(subgraph.find_node_by_id(1).unwrap().outputs, vec![2]);
+        assert_eq!(subgraph.find_node_by_id(2).unwrap().inputs, vec![1]);
+        assert_eq!(subgraph.find_node_by_id(2).unwrap().outputs, vec![3]);
+        assert_eq!(subgraph.find_node_by_id(3).unwrap().inputs, vec![2]);
+        subgraph.verify().unwrap();
     }
 
     #[test]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -583,6 +583,7 @@ impl Graph {
                 inputs: node.inputs.iter().map(|index| index_map[index]).collect(),
                 outputs: node.outputs.iter().map(|index| index_map[index]).collect(),
                 kind: node.kind,
+                tag: node.tag,
                 ..Default::default()
             })
             .collect::<Vec<_>>();
@@ -616,6 +617,7 @@ impl Graph {
                 inputs: node.inputs.iter().map(|index| indexs[index]).collect(),
                 outputs: node.outputs.iter().map(|index| indexs[index]).collect(),
                 kind: node.kind,
+                tag: node.tag,
                 ..Default::default()
             })
             .collect::<Vec<_>>();

--- a/src/graph/world.rs
+++ b/src/graph/world.rs
@@ -24,6 +24,24 @@ impl Verify for WorldGraph {
 }
 
 impl WorldGraph {
+    pub fn extract_subgraph_by_node_ids(&self, node_ids: &HashSet<GraphNodeId>) -> Self {
+        Self {
+            graph: self.graph.extract_graph_by_node_ids(node_ids),
+            positions: self
+                .positions
+                .iter()
+                .filter(|(node_id, _)| node_ids.contains(node_id))
+                .map(|(node_id, position)| (*node_id, *position))
+                .collect(),
+            routings: self
+                .routings
+                .iter()
+                .filter(|node_id| node_ids.contains(node_id))
+                .copied()
+                .collect(),
+        }
+    }
+
     pub fn replace_nodes_with(
         &mut self,
         removed_nodes: &HashSet<GraphNodeId>,

--- a/src/graph/world.rs
+++ b/src/graph/world.rs
@@ -23,6 +23,33 @@ impl Verify for WorldGraph {
     }
 }
 
+impl WorldGraph {
+    pub fn replace_nodes_with(
+        &mut self,
+        removed_nodes: &HashSet<GraphNodeId>,
+        kind: GraphNodeKind,
+        inputs: Vec<GraphNodeId>,
+        outputs: Vec<GraphNodeId>,
+        tag: String,
+    ) -> GraphNodeId {
+        let position = removed_nodes
+            .iter()
+            .find_map(|node_id| self.positions.get(node_id).copied());
+        let replacement_id =
+            self.graph
+                .replace_nodes_with(removed_nodes, kind, inputs, outputs, tag);
+        for node_id in removed_nodes {
+            self.positions.remove(node_id);
+            self.routings.remove(node_id);
+        }
+        if let Some(position) = position {
+            self.positions.insert(replacement_id, position);
+        }
+
+        replacement_id
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct WorldGraphBuilder {
     world: World3D,

--- a/src/transform/place_and_route/utils.rs
+++ b/src/transform/place_and_route/utils.rs
@@ -170,7 +170,10 @@ mod tests {
     #[test]
     fn source_tag_match_accepts_plain_and_annotated_source_tags() {
         assert!(is_source_tag("From #12", 12));
-        assert!(is_source_tag("From #12: Folded redstone component [3, 4]", 12));
+        assert!(is_source_tag(
+            "From #12: Folded redstone component [3, 4]",
+            12
+        ));
         assert!(!is_source_tag("From #123", 12));
         assert!(!is_source_tag("From #12-ish", 12));
     }

--- a/src/transform/place_and_route/utils.rs
+++ b/src/transform/place_and_route/utils.rs
@@ -51,7 +51,7 @@ pub fn world_to_logic_with_outputs(
             } else if let Some(node) = logic_graph
                 .nodes
                 .iter()
-                .filter(|node| node.tag == format!("From #{source_id}"))
+                .filter(|node| is_source_tag(&node.tag, source_id))
                 .max_by_key(|node| node.id)
             {
                 node.id
@@ -68,6 +68,11 @@ pub fn world_to_logic_with_outputs(
         .collect::<eyre::Result<Vec<_>>>()?;
 
     normalize_logic_graph(logic_graph.attach_outputs(outputs)?)
+}
+
+fn is_source_tag(tag: &str, source_id: GraphNodeId) -> bool {
+    let source = format!("From #{source_id}");
+    tag == source || tag.starts_with(&format!("{source}: "))
 }
 
 fn resolve_folded_output_source(
@@ -156,6 +161,19 @@ fn component_external_edges(
         })
         .filter(|node_id| !component.contains(node_id))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_source_tag;
+
+    #[test]
+    fn source_tag_match_accepts_plain_and_annotated_source_tags() {
+        assert!(is_source_tag("From #12", 12));
+        assert!(is_source_tag("From #12: Folded redstone component [3, 4]", 12));
+        assert!(!is_source_tag("From #123", 12));
+        assert!(!is_source_tag("From #12-ish", 12));
+    }
 }
 
 pub fn equivalent_graph(src: &LogicGraph, tar: &LogicGraph) -> bool {

--- a/src/transform/world.rs
+++ b/src/transform/world.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 
 use crate::graph::world::WorldGraph;
 use crate::graph::{GraphNode, GraphNodeId, GraphNodeKind};
+use crate::sequential::SequentialPrimitive;
 use crate::world::block::{Block, BlockKind, Direction};
 
 pub struct WorldGraphTransformer {
@@ -134,6 +135,31 @@ impl WorldGraphTransformer {
         self.graph.graph.build_consumers();
     }
 
+    // Collapse physical RS-latch feedback loops before converting the world graph
+    // into logic. The downstream logic extraction walks nodes in topological order,
+    // so a cyclic torch/redstone latch core must become one sequential node first.
+    pub fn fold_rs_latch_feedback_components(&mut self) {
+        for component in self.graph.graph.strongly_connected_components() {
+            let component_set = component.iter().copied().collect::<HashSet<_>>();
+            if !is_rs_latch_feedback_component(&self.graph, &component, &component_set) {
+                continue;
+            }
+
+            let inputs = self.graph.graph.external_edges(&component_set, true);
+            if inputs.len() != 2 {
+                continue;
+            }
+            let outputs = self.graph.graph.external_edges(&component_set, false);
+            self.graph.replace_nodes_with(
+                &component_set,
+                GraphNodeKind::Sequential(SequentialPrimitive::rs_latch()),
+                inputs,
+                outputs,
+                format!("Folded RS latch feedback SCC {component:?}"),
+            );
+        }
+    }
+
     pub fn remove_redstone(&mut self) {
         self.remove_specific_kind_of_block(
             |kind| matches!(&kind, BlockKind::Redstone { .. }),
@@ -171,6 +197,44 @@ impl WorldGraphTransformer {
         self.graph.graph.build_producers();
         self.graph.graph.build_consumers();
     }
+}
+
+// Recognize the narrow post-redstone-fold shape used by the current RS latch
+// fixtures: two torches cross-coupled through two folded redstone routing nodes.
+// Input gating around that core, such as in a D latch, stays outside the SCC and
+// remains ordinary combinational logic.
+fn is_rs_latch_feedback_component(
+    graph: &WorldGraph,
+    component: &[GraphNodeId],
+    component_set: &HashSet<GraphNodeId>,
+) -> bool {
+    if component.len() != 4 {
+        return false;
+    }
+
+    let mut torch_count = 0;
+    let mut redstone_count = 0;
+    for node_id in component {
+        let Some(node) = graph.graph.find_node_by_id(*node_id) else {
+            return false;
+        };
+        match &node.kind {
+            GraphNodeKind::Block(block) if matches!(block.kind, BlockKind::Torch { .. }) => {
+                torch_count += 1;
+                if !node.inputs.iter().any(|id| component_set.contains(id))
+                    || !node.outputs.iter().any(|id| component_set.contains(id))
+                {
+                    return false;
+                }
+            }
+            GraphNodeKind::Block(block) if matches!(block.kind, BlockKind::Redstone { .. }) => {
+                redstone_count += 1;
+            }
+            _ => return false,
+        }
+    }
+
+    torch_count == 2 && redstone_count == 2
 }
 
 #[cfg(test)]

--- a/src/transform/world.rs
+++ b/src/transform/world.rs
@@ -58,6 +58,7 @@ impl WorldGraphTransformer {
         let ids: HashSet<GraphNodeId> = nodes.iter().map(|node| node.id).collect();
         let mut group_inputs: HashMap<usize, HashSet<GraphNodeId>> = HashMap::new();
         let mut group_outputs: HashMap<usize, HashSet<GraphNodeId>> = HashMap::new();
+        let mut group_members: HashMap<usize, Vec<GraphNodeId>> = HashMap::new();
 
         let mut group_ids: HashSet<usize> = HashSet::new();
 
@@ -65,6 +66,7 @@ impl WorldGraphTransformer {
             // make clustered id group
             let group_id = cluster.find(*id).unwrap();
             group_ids.insert(group_id);
+            group_members.entry(group_id).or_default().push(*id);
 
             // collect group input outputs
             group_inputs.entry(group_id).or_default().extend(
@@ -83,13 +85,16 @@ impl WorldGraphTransformer {
 
         // make clustered node
         let mut next_id = self.graph.graph.max_node_id().unwrap();
+        for members in group_members.values_mut() {
+            members.sort_unstable();
+        }
 
         // remove redstone node
         for id in &ids {
             self.graph.graph.remove_by_node_id_lazy(*id);
         }
 
-        for group_id in &group_ids {
+        for group_id in group_ids.iter().sorted() {
             next_id += 1;
 
             let node = GraphNode {
@@ -105,6 +110,10 @@ impl WorldGraphTransformer {
                 // TODO: optimize this
                 inputs: group_inputs[group_id].clone().into_iter().collect_vec(),
                 outputs: group_outputs[group_id].clone().into_iter().collect_vec(),
+                tag: format!(
+                    "Folded redstone component {:?}",
+                    group_members.get(group_id).unwrap()
+                ),
                 ..Default::default()
             };
 
@@ -250,9 +259,24 @@ mod tests {
         let g = WorldGraphBuilder::new(&nbt.to_world()).build();
 
         let mut transform = WorldGraphTransformer::new(g);
+        transform.fold_redstone();
+        let folded = transform.finish();
+
+        assert!(
+            folded
+                .graph
+                .nodes
+                .iter()
+                .any(|node| node.tag.contains("Folded redstone component")),
+            "expected folded redstone nodes to keep their source component tag"
+        );
+
+        let mut transform = WorldGraphTransformer::new(folded);
         transform.remove_redstone();
         transform.remove_repeater();
-        println!("{}", transform.finish().to_graphviz());
+        if std::env::var_os("PRINT_WORLD_GRAPHS").is_some() {
+            println!("{}", transform.finish().to_graphviz());
+        }
 
         Ok(())
     }

--- a/src/transform/world_to_logic.rs
+++ b/src/transform/world_to_logic.rs
@@ -96,6 +96,7 @@ impl WorldToLogicTransformer {
                 .map(|id| new_in_id.get(id).unwrap_or(id))
                 .copied()
                 .collect();
+            let tag = transformed_tag(id, &node.tag);
 
             let new_nodes = match node.kind {
                 GraphNodeKind::Sequential(sequential) => {
@@ -104,7 +105,7 @@ impl WorldToLogicTransformer {
                         kind: GraphNodeKind::Sequential(sequential),
                         inputs,
                         outputs: node.outputs,
-                        tag: format!("From #{id}"),
+                        tag,
                     }]
                 }
                 GraphNodeKind::Block(block) => match block.kind {
@@ -116,7 +117,7 @@ impl WorldToLogicTransformer {
                             kind: GraphNodeKind::Input(format!("#{}", input_count)),
                             inputs,
                             outputs: node.outputs,
-                            tag: format!("From #{id}"),
+                            tag,
                         }]
                     }
                     BlockKind::Redstone { .. } | BlockKind::Repeater { .. } => {
@@ -127,7 +128,7 @@ impl WorldToLogicTransformer {
                             }),
                             inputs,
                             outputs: node.outputs,
-                            tag: format!("From #{id}"),
+                            tag,
                         }]
                     }
                     BlockKind::Torch { .. } => {
@@ -139,7 +140,7 @@ impl WorldToLogicTransformer {
                                 }),
                                 inputs,
                                 outputs: node.outputs,
-                                tag: format!("From #{id}"),
+                                tag,
                             }]
                         } else {
                             next_new_id += 1;
@@ -151,7 +152,7 @@ impl WorldToLogicTransformer {
                                 }),
                                 inputs,
                                 outputs: vec![next_new_id],
-                                tag: format!("From #{id}"),
+                                tag: tag.clone(),
                             };
 
                             let not_node = GraphNode {
@@ -161,7 +162,7 @@ impl WorldToLogicTransformer {
                                 }),
                                 inputs: vec![or_node.id],
                                 outputs: node.outputs.clone(),
-                                tag: format!("From #{id}"),
+                                tag,
                             };
 
                             new_in_id.insert(or_node.id, next_new_id);
@@ -192,6 +193,14 @@ impl WorldToLogicTransformer {
         }
 
         Ok(LogicGraph { graph })
+    }
+}
+
+fn transformed_tag(source_id: GraphNodeId, tag: &str) -> String {
+    if tag.is_empty() {
+        format!("From #{source_id}")
+    } else {
+        format!("From #{source_id}: {tag}")
     }
 }
 
@@ -270,6 +279,13 @@ mod tests {
                 .iter()
                 .any(|node| matches!(node.kind, crate::graph::GraphNodeKind::Sequential(_))),
             "expected RS latch NBT to contain a sequential logic node"
+        );
+        assert!(
+            logic
+                .nodes
+                .iter()
+                .any(|node| node.tag.contains("Folded RS latch feedback SCC")),
+            "expected folded RS latch tag to be visible in the logic graph"
         );
 
         Ok(())

--- a/src/transform/world_to_logic.rs
+++ b/src/transform/world_to_logic.rs
@@ -56,6 +56,7 @@ impl WorldToLogicTransformer {
     fn optimize(graph: WorldGraph, remain_routings: bool) -> WorldGraph {
         let mut transform = WorldGraphTransformer::new(graph);
         transform.fold_redstone();
+        transform.fold_rs_latch_feedback_components();
         if !remain_routings {
             transform.remove_redstone();
             transform.remove_repeater();
@@ -96,68 +97,80 @@ impl WorldToLogicTransformer {
                 .copied()
                 .collect();
 
-            let new_nodes = match node.kind.as_block().unwrap().kind {
-                BlockKind::Switch { .. } => {
-                    input_count += 1;
+            let new_nodes = match node.kind {
+                GraphNodeKind::Sequential(sequential) => {
+                    vec![GraphNode {
+                        id: node.id,
+                        kind: GraphNodeKind::Sequential(sequential),
+                        inputs,
+                        outputs: node.outputs,
+                        tag: format!("From #{id}"),
+                    }]
+                }
+                GraphNodeKind::Block(block) => match block.kind {
+                    BlockKind::Switch { .. } => {
+                        input_count += 1;
 
-                    vec![GraphNode {
-                        id: node.id,
-                        kind: GraphNodeKind::Input(format!("#{}", input_count)),
-                        inputs,
-                        outputs: node.outputs,
-                        tag: format!("From #{id}"),
-                    }]
-                }
-                BlockKind::Redstone { .. } | BlockKind::Repeater { .. } => {
-                    vec![GraphNode {
-                        id: node.id,
-                        kind: GraphNodeKind::Logic(Logic {
-                            logic_type: LogicType::Or,
-                        }),
-                        inputs,
-                        outputs: node.outputs,
-                        tag: format!("From #{id}"),
-                    }]
-                }
-                BlockKind::Torch { .. } => {
-                    if node.inputs.len() == 1 {
                         vec![GraphNode {
                             id: node.id,
-                            kind: GraphNodeKind::Logic(Logic {
-                                logic_type: LogicType::Not,
-                            }),
+                            kind: GraphNodeKind::Input(format!("#{}", input_count)),
                             inputs,
                             outputs: node.outputs,
                             tag: format!("From #{id}"),
                         }]
-                    } else {
-                        next_new_id += 1;
-
-                        let or_node = GraphNode {
+                    }
+                    BlockKind::Redstone { .. } | BlockKind::Repeater { .. } => {
+                        vec![GraphNode {
                             id: node.id,
                             kind: GraphNodeKind::Logic(Logic {
                                 logic_type: LogicType::Or,
                             }),
                             inputs,
-                            outputs: vec![next_new_id],
+                            outputs: node.outputs,
                             tag: format!("From #{id}"),
-                        };
-
-                        let not_node = GraphNode {
-                            id: next_new_id,
-                            kind: GraphNodeKind::Logic(Logic {
-                                logic_type: LogicType::Not,
-                            }),
-                            inputs: vec![or_node.id],
-                            outputs: node.outputs.clone(),
-                            tag: format!("From #{id}"),
-                        };
-
-                        new_in_id.insert(or_node.id, next_new_id);
-
-                        vec![or_node, not_node]
+                        }]
                     }
-                }
+                    BlockKind::Torch { .. } => {
+                        if node.inputs.len() == 1 {
+                            vec![GraphNode {
+                                id: node.id,
+                                kind: GraphNodeKind::Logic(Logic {
+                                    logic_type: LogicType::Not,
+                                }),
+                                inputs,
+                                outputs: node.outputs,
+                                tag: format!("From #{id}"),
+                            }]
+                        } else {
+                            next_new_id += 1;
+
+                            let or_node = GraphNode {
+                                id: node.id,
+                                kind: GraphNodeKind::Logic(Logic {
+                                    logic_type: LogicType::Or,
+                                }),
+                                inputs,
+                                outputs: vec![next_new_id],
+                                tag: format!("From #{id}"),
+                            };
+
+                            let not_node = GraphNode {
+                                id: next_new_id,
+                                kind: GraphNodeKind::Logic(Logic {
+                                    logic_type: LogicType::Not,
+                                }),
+                                inputs: vec![or_node.id],
+                                outputs: node.outputs.clone(),
+                                tag: format!("From #{id}"),
+                            };
+
+                            new_in_id.insert(or_node.id, next_new_id);
+
+                            vec![or_node, not_node]
+                        }
+                    }
+                    _ => todo!(),
+                },
                 _ => todo!(),
             };
 
@@ -242,6 +255,38 @@ mod tests {
         let world = &nbt.to_world();
         let expected = predefined_logics::buffered_half_adder_graph()?;
         assert!(equivalent_logic_with_world(&expected, world)?);
+
+        Ok(())
+    }
+
+    #[test]
+    fn world_to_logic_extracts_rs_latch_nbt_as_sequential_node() -> eyre::Result<()> {
+        let nbt = NBTRoot::load("test/rs-latch.nbt")?;
+        let logic = crate::transform::place_and_route::utils::world_to_logic(&nbt.to_world())?;
+
+        assert!(
+            logic
+                .nodes
+                .iter()
+                .any(|node| matches!(node.kind, crate::graph::GraphNodeKind::Sequential(_))),
+            "expected RS latch NBT to contain a sequential logic node"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn world_to_logic_extracts_d_latch_nbt_as_sequential_node() -> eyre::Result<()> {
+        let nbt = NBTRoot::load("test/d-latch.nbt")?;
+        let logic = crate::transform::place_and_route::utils::world_to_logic(&nbt.to_world())?;
+
+        assert!(
+            logic
+                .nodes
+                .iter()
+                .any(|node| matches!(node.kind, crate::graph::GraphNodeKind::Sequential(_))),
+            "expected D latch NBT to contain a sequential logic node"
+        );
 
         Ok(())
     }

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -167,10 +167,55 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
         <div id="graph-status" class="graph-status">Open an NBT file to inspect graphs.</div>
         <div class="graph-viewer">
           <div id="graph-output" class="graph-output"></div>
+          <div id="graph-selection-actions" class="graph-selection-actions hidden">
+            <button id="open-selected-graph" class="graph-selection-button" type="button">Open Selection</button>
+            <button id="open-selected-nbt" class="graph-selection-button" type="button">Open Selection As NBT</button>
+          </div>
           <div id="graph-minimap" class="graph-minimap hidden" aria-hidden="true">
             <div id="graph-minimap-content" class="graph-minimap-content"></div>
             <div id="graph-minimap-viewport" class="graph-minimap-viewport"></div>
           </div>
+        </div>
+      </div>
+    </dialog>
+    <dialog id="selected-graph-dialog" class="graph-dialog">
+      <div class="graph-dialog-surface">
+        <header class="graph-dialog-header">
+          <strong>Selected Graphs</strong>
+          <button id="close-selected-graphs" class="panel-action" type="button">Close</button>
+        </header>
+        <div class="graph-tabs" role="tablist" aria-label="Selected graph views">
+          <button id="selected-graph-world-tab" class="graph-tab active" type="button" role="tab">World Graph</button>
+          <button id="selected-graph-logic-tab" class="graph-tab" type="button" role="tab">Logic Graph</button>
+          <div id="selected-graph-world-mode" class="graph-world-mode" aria-label="Selected world graph mode">
+            <button id="selected-graph-world-raw" class="graph-mode-button active" type="button">Raw</button>
+            <button id="selected-graph-world-folded" class="graph-mode-button" type="button">Folded</button>
+          </div>
+          <label class="graph-tag-toggle">
+            <input id="selected-graph-show-tags" type="checkbox" checked />
+            <span>Show Tag</span>
+          </label>
+          <div class="graph-zoom-controls" aria-label="Selected graph zoom">
+            <button id="selected-graph-zoom-out" class="graph-zoom-button" type="button" aria-label="Zoom out">-</button>
+            <button id="selected-graph-zoom-reset" class="graph-zoom-value" type="button" aria-label="Reset zoom">100%</button>
+            <button id="selected-graph-zoom-in" class="graph-zoom-button" type="button" aria-label="Zoom in">+</button>
+          </div>
+        </div>
+        <div id="selected-graph-status" class="graph-status">Select world graph nodes to open a focused graph.</div>
+        <div class="graph-viewer">
+          <div id="selected-graph-output" class="graph-output"></div>
+        </div>
+      </div>
+    </dialog>
+    <dialog id="selected-nbt-dialog" class="graph-dialog selected-nbt-dialog">
+      <div class="graph-dialog-surface selected-nbt-dialog-surface">
+        <header class="graph-dialog-header">
+          <strong>Selected NBT</strong>
+          <button id="close-selected-nbt" class="panel-action" type="button">Close</button>
+        </header>
+        <div id="selected-nbt-status" class="graph-status">Select world graph nodes to open focused NBT.</div>
+        <div class="selected-nbt-viewer">
+          <canvas id="selected-nbt-canvas"></canvas>
         </div>
       </div>
     </dialog>
@@ -213,13 +258,35 @@ const graphZoomOutButton = document.querySelector<HTMLButtonElement>('#graph-zoo
 const graphZoomResetButton = document.querySelector<HTMLButtonElement>('#graph-zoom-reset')!;
 const graphZoomInButton = document.querySelector<HTMLButtonElement>('#graph-zoom-in')!;
 const graphStatus = document.querySelector<HTMLElement>('#graph-status')!;
+const graphViewer = document.querySelector<HTMLElement>('.graph-viewer')!;
 const graphOutput = document.querySelector<HTMLElement>('#graph-output')!;
+const graphSelectionActions = document.querySelector<HTMLElement>('#graph-selection-actions')!;
+const openSelectedGraphButton = document.querySelector<HTMLButtonElement>('#open-selected-graph')!;
+const openSelectedNbtButton = document.querySelector<HTMLButtonElement>('#open-selected-nbt')!;
 const graphMinimap = document.querySelector<HTMLElement>('#graph-minimap')!;
 const graphMinimapContent = document.querySelector<HTMLElement>('#graph-minimap-content')!;
 const graphMinimapViewport = document.querySelector<HTMLElement>('#graph-minimap-viewport')!;
+const selectedGraphDialog = document.querySelector<HTMLDialogElement>('#selected-graph-dialog')!;
+const closeSelectedGraphsButton = document.querySelector<HTMLButtonElement>('#close-selected-graphs')!;
+const selectedGraphWorldTab = document.querySelector<HTMLButtonElement>('#selected-graph-world-tab')!;
+const selectedGraphLogicTab = document.querySelector<HTMLButtonElement>('#selected-graph-logic-tab')!;
+const selectedGraphWorldMode = document.querySelector<HTMLElement>('#selected-graph-world-mode')!;
+const selectedGraphWorldRawButton = document.querySelector<HTMLButtonElement>('#selected-graph-world-raw')!;
+const selectedGraphWorldFoldedButton = document.querySelector<HTMLButtonElement>('#selected-graph-world-folded')!;
+const selectedGraphShowTagsInput = document.querySelector<HTMLInputElement>('#selected-graph-show-tags')!;
+const selectedGraphZoomOutButton = document.querySelector<HTMLButtonElement>('#selected-graph-zoom-out')!;
+const selectedGraphZoomResetButton = document.querySelector<HTMLButtonElement>('#selected-graph-zoom-reset')!;
+const selectedGraphZoomInButton = document.querySelector<HTMLButtonElement>('#selected-graph-zoom-in')!;
+const selectedGraphStatus = document.querySelector<HTMLElement>('#selected-graph-status')!;
+const selectedGraphOutput = document.querySelector<HTMLElement>('#selected-graph-output')!;
+const selectedNbtDialog = document.querySelector<HTMLDialogElement>('#selected-nbt-dialog')!;
+const closeSelectedNbtButton = document.querySelector<HTMLButtonElement>('#close-selected-nbt')!;
+const selectedNbtStatus = document.querySelector<HTMLElement>('#selected-nbt-status')!;
+const selectedNbtCanvas = document.querySelector<HTMLCanvasElement>('#selected-nbt-canvas')!;
 
 const viewer = new StructureViewer(canvas);
 viewer.setSelectionHandler(renderSelection);
+const selectedNbtViewer = new StructureViewer(selectedNbtCanvas);
 
 let simulation: NbtSimulation | undefined;
 let selectedBlock: StructureBlock | undefined;
@@ -241,6 +308,11 @@ let graphMinimapScale = 1;
 let isDraggingGraphMinimap = false;
 let graphZoom = 1;
 let selectedGraphNode: string | undefined;
+let selectedGraphDot: GraphDotInfo | undefined;
+let selectedGraphTab: GraphTab = 'world';
+let selectedGraphWorldModeValue: GraphWorldMode = 'raw';
+let selectedGraphShowTags = true;
+let selectedGraphZoom = 1;
 
 folderInput.setAttribute('webkitdirectory', '');
 folderInput.setAttribute('directory', '');
@@ -338,6 +410,82 @@ graphZoomInButton.addEventListener('click', () => {
   setGraphZoom(graphZoom + 0.25);
 });
 
+openSelectedGraphButton.addEventListener('click', () => {
+  void openSelectedGraphView();
+});
+
+openSelectedNbtButton.addEventListener('click', () => {
+  void openSelectedNbtView();
+});
+
+closeSelectedGraphsButton.addEventListener('click', () => {
+  selectedGraphDialog.close();
+});
+
+selectedGraphDialog.addEventListener('click', event => {
+  if (event.target === selectedGraphDialog) {
+    selectedGraphDialog.close();
+  }
+});
+
+closeSelectedNbtButton.addEventListener('click', () => {
+  selectedNbtDialog.close();
+});
+
+selectedNbtDialog.addEventListener('click', event => {
+  if (event.target === selectedNbtDialog) {
+    selectedNbtDialog.close();
+  }
+});
+
+selectedGraphWorldTab.addEventListener('click', () => {
+  selectedGraphTab = 'world';
+  void renderSelectedGraphTab();
+});
+
+selectedGraphLogicTab.addEventListener('click', () => {
+  selectedGraphTab = 'logic';
+  void renderSelectedGraphTab();
+});
+
+selectedGraphWorldRawButton.addEventListener('click', () => {
+  selectedGraphWorldModeValue = 'raw';
+  void renderSelectedGraphTab();
+});
+
+selectedGraphWorldFoldedButton.addEventListener('click', () => {
+  selectedGraphWorldModeValue = 'folded';
+  void renderSelectedGraphTab();
+});
+
+selectedGraphShowTagsInput.addEventListener('change', () => {
+  selectedGraphShowTags = selectedGraphShowTagsInput.checked;
+  void renderSelectedGraphTab();
+});
+
+selectedGraphZoomOutButton.addEventListener('click', () => {
+  setSelectedGraphZoom(selectedGraphZoom - 0.25);
+});
+
+selectedGraphZoomResetButton.addEventListener('click', () => {
+  setSelectedGraphZoom(1);
+});
+
+selectedGraphZoomInButton.addEventListener('click', () => {
+  setSelectedGraphZoom(selectedGraphZoom + 0.25);
+});
+
+selectedGraphOutput.addEventListener(
+  'wheel',
+  event => {
+    if (!event.ctrlKey) return;
+
+    event.preventDefault();
+    zoomSelectedGraphAt(event.clientX, event.clientY, selectedGraphZoom * (event.deltaY < 0 ? 1.12 : 1 / 1.12));
+  },
+  { passive: false },
+);
+
 graphOutput.addEventListener('scroll', () => {
   updateGraphMinimapViewport();
 });
@@ -420,6 +568,8 @@ async function renderGraphTab(): Promise<void> {
   updateGraphTabs();
   graphOutput.replaceChildren();
   clearGraphMinimap();
+  graphSelectionActions.classList.add('hidden');
+  graphViewer.classList.remove('has-selection-action');
 
   if (!graphDot) {
     graphStatus.textContent = currentNbtBytes ? 'Generating graphs...' : 'Open an NBT file before viewing graphs.';
@@ -441,7 +591,7 @@ async function renderGraphTab(): Promise<void> {
     graphOutput.append(svg);
     installGraphNodeHitAreas(svg);
     bindGraphSelection(svg);
-    applyGraphZoom();
+    setGraphZoom(1);
     renderGraphMinimap(svg);
   } catch (error) {
     graphStatus.textContent = error instanceof Error ? error.message : String(error);
@@ -566,7 +716,66 @@ function updateGraphSelectionStatus(): void {
       : graphWorldModeValue === 'folded'
         ? 'World Graph - Folded'
         : 'World Graph - Raw';
-  graphStatus.textContent = selectedGraphNode ? `${title} - ${selectedGraphNode} selected` : title;
+  const selectedCount = selectedGraphNode ? graphOutput.querySelectorAll('svg g.node.graph-node-selected').length : 0;
+  graphStatus.textContent = selectedGraphNode ? `${title} - ${selectedGraphNode} selected (${selectedCount} nodes)` : title;
+  const canOpenSelection = graphTab === 'world' && selectedCount > 0;
+  graphSelectionActions.classList.toggle('hidden', !canOpenSelection);
+  graphViewer.classList.toggle('has-selection-action', canOpenSelection);
+}
+
+async function openSelectedGraphView(): Promise<void> {
+  const sourceSvg = graphOutput.querySelector<SVGSVGElement>('svg');
+  if (graphTab !== 'world' || !sourceSvg || !selectedGraphNode) return;
+
+  const nodeIds = selectedWorldGraphNodeIds(sourceSvg);
+  if (nodeIds.length === 0 || !currentNbtBytes) return;
+
+  if (!selectedGraphDialog.open) selectedGraphDialog.showModal();
+  selectedGraphOutput.replaceChildren();
+  selectedGraphStatus.textContent = 'Generating selected graph...';
+  selectedGraphDot = undefined;
+  selectedGraphTab = 'world';
+  selectedGraphWorldModeValue = graphWorldModeValue;
+  selectedGraphShowTags = graphShowTags;
+  selectedGraphShowTagsInput.checked = selectedGraphShowTags;
+
+  try {
+    selectedGraphDot = await NbtSimulation.selectedGraphDot(currentNbtBytes, graphWorldModeValue === 'folded', nodeIds);
+    await renderSelectedGraphTab();
+  } catch (error) {
+    selectedGraphStatus.textContent = error instanceof Error ? error.message : String(error);
+  }
+}
+
+async function openSelectedNbtView(): Promise<void> {
+  const sourceSvg = graphOutput.querySelector<SVGSVGElement>('svg');
+  if (graphTab !== 'world' || !sourceSvg || !selectedGraphNode) return;
+
+  const nodeIds = selectedWorldGraphNodeIds(sourceSvg);
+  if (nodeIds.length === 0 || !currentNbtBytes) return;
+
+  if (!selectedNbtDialog.open) selectedNbtDialog.showModal();
+  selectedNbtStatus.textContent = 'Generating selected NBT...';
+
+  try {
+    const selectedRoot = await NbtSimulation.selectedNbt(currentNbtBytes, graphWorldModeValue === 'folded', nodeIds);
+    const structure = toStructureModel(selectedRoot);
+    if (!structure) {
+      selectedNbtStatus.textContent = 'Selected graph did not produce a structure.';
+      return;
+    }
+
+    await selectedNbtViewer.setStructure(structure);
+    selectedNbtStatus.textContent = `Selected NBT - ${structure.blocks.length} blocks`;
+  } catch (error) {
+    selectedNbtStatus.textContent = error instanceof Error ? error.message : String(error);
+  }
+}
+
+function selectedWorldGraphNodeIds(sourceSvg: SVGSVGElement): number[] {
+  return Array.from(sourceSvg.querySelectorAll<SVGGElement>('g.node.graph-node-selected'))
+    .map(node => parseGraphNodeId(graphElementTitle(node)))
+    .filter((nodeId): nodeId is number => nodeId !== undefined);
 }
 
 function graphNodeElements(svg: SVGSVGElement): Map<string, SVGGElement> {
@@ -593,6 +802,62 @@ function parseGraphEdgeTitle(title: string | undefined): { source: string; targe
   const match = title?.match(/^(node\d+)(?::[^-]+)?->(node\d+)(?::.+)?$/);
   if (!match) return undefined;
   return { source: match[1], target: match[2] };
+}
+
+function parseGraphNodeId(title: string | undefined): number | undefined {
+  const match = title?.match(/^node(\d+)$/);
+  if (!match) return undefined;
+
+  const nodeId = Number(match[1]);
+  return Number.isInteger(nodeId) ? nodeId : undefined;
+}
+
+async function renderSelectedGraphTab(): Promise<void> {
+  updateSelectedGraphTabs();
+  selectedGraphOutput.replaceChildren();
+
+  if (!selectedGraphDot) {
+    selectedGraphStatus.textContent = 'Select world graph nodes to open a focused graph.';
+    return;
+  }
+
+  selectedGraphStatus.textContent =
+    selectedGraphTab === 'logic'
+      ? 'Selected Logic Graph'
+      : selectedGraphWorldModeValue === 'folded'
+        ? 'Selected World Graph - Folded'
+        : 'Selected World Graph - Raw';
+
+  try {
+    const viz = await loadViz();
+    const svg = viz.renderSVGElement(currentSelectedGraphDot(), { engine: 'dot' });
+    selectedGraphOutput.append(svg);
+    setSelectedGraphZoom(1);
+  } catch (error) {
+    selectedGraphStatus.textContent = error instanceof Error ? error.message : String(error);
+  }
+}
+
+function currentSelectedGraphDot(): string {
+  if (!selectedGraphDot) return '';
+
+  if (selectedGraphTab === 'logic') {
+    return selectedGraphShowTags ? selectedGraphDot.logicDot : selectedGraphDot.logicDotWithoutTags;
+  }
+
+  if (selectedGraphWorldModeValue === 'folded') {
+    return selectedGraphShowTags ? selectedGraphDot.foldedWorldDot : selectedGraphDot.foldedWorldDotWithoutTags;
+  }
+
+  return selectedGraphShowTags ? selectedGraphDot.rawWorldDot : selectedGraphDot.rawWorldDotWithoutTags;
+}
+
+function updateSelectedGraphTabs(): void {
+  selectedGraphWorldTab.classList.toggle('active', selectedGraphTab === 'world');
+  selectedGraphLogicTab.classList.toggle('active', selectedGraphTab === 'logic');
+  selectedGraphWorldMode.classList.toggle('hidden', selectedGraphTab !== 'world');
+  selectedGraphWorldRawButton.classList.toggle('active', selectedGraphWorldModeValue === 'raw');
+  selectedGraphWorldFoldedButton.classList.toggle('active', selectedGraphWorldModeValue === 'folded');
 }
 
 async function loadViz(): Promise<Viz> {
@@ -644,15 +909,54 @@ function applyGraphZoom(options: { refreshMinimap?: boolean } = {}): void {
 
 }
 
+function setSelectedGraphZoom(nextZoom: number): void {
+  selectedGraphZoom = Math.max(0.25, Math.min(3, nextZoom));
+  applySelectedGraphZoom();
+}
+
+function zoomSelectedGraphAt(clientX: number, clientY: number, nextZoom: number): void {
+  const previousZoom = selectedGraphZoom;
+  const clampedZoom = Math.max(0.25, Math.min(3, nextZoom));
+  if (clampedZoom === previousZoom) return;
+
+  const outputRect = selectedGraphOutput.getBoundingClientRect();
+  const focusX = selectedGraphOutput.scrollLeft + clientX - outputRect.left;
+  const focusY = selectedGraphOutput.scrollTop + clientY - outputRect.top;
+  selectedGraphZoom = clampedZoom;
+  applySelectedGraphZoom();
+
+  const ratio = clampedZoom / previousZoom;
+  selectedGraphOutput.scrollLeft = focusX * ratio - (clientX - outputRect.left);
+  selectedGraphOutput.scrollTop = focusY * ratio - (clientY - outputRect.top);
+}
+
+function applySelectedGraphZoom(): void {
+  selectedGraphZoomResetButton.textContent = `${Math.round(selectedGraphZoom * 100)}%`;
+  selectedGraphZoomOutButton.disabled = selectedGraphZoom <= 0.25;
+  selectedGraphZoomInButton.disabled = selectedGraphZoom >= 3;
+
+  const svg = selectedGraphOutput.querySelector<SVGSVGElement>('svg');
+  if (!svg) return;
+
+  const baseWidth = readSvgBaseSize(svg, 'width', selectedGraphZoom, selectedGraphOutput);
+  const baseHeight = readSvgBaseSize(svg, 'height', selectedGraphZoom, selectedGraphOutput);
+  svg.style.width = `${baseWidth * selectedGraphZoom}px`;
+  svg.style.height = `${baseHeight * selectedGraphZoom}px`;
+}
+
 function readGraphBaseSize(svg: SVGSVGElement, dimension: 'width' | 'height'): number {
+  return readSvgBaseSize(svg, dimension, graphZoom, graphOutput);
+}
+
+function readSvgBaseSize(svg: SVGSVGElement, dimension: 'width' | 'height', zoom: number, fallbackElement: HTMLElement): number {
   const dataKey = `base${dimension[0].toUpperCase()}${dimension.slice(1)}`;
   const cached = Number(svg.dataset[dataKey]);
   if (Number.isFinite(cached) && cached > 0) return cached;
 
   const rect = svg.getBoundingClientRect();
   const measured = dimension === 'width' ? rect.width : rect.height;
-  const fallback = dimension === 'width' ? graphOutput.clientWidth : graphOutput.clientHeight;
-  const value = Math.max(measured / graphZoom, fallback, 1);
+  const fallback = dimension === 'width' ? fallbackElement.clientWidth : fallbackElement.clientHeight;
+  const value = Math.max(measured / zoom, fallback, 1);
   svg.dataset[dataKey] = String(value);
   return value;
 }

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -56,6 +56,7 @@ type TraceAnimation = {
   token: number;
 };
 type GraphTab = 'world' | 'logic';
+type GraphWorldMode = 'raw' | 'folded';
 type ExampleFile = {
   name: string;
   path: string;
@@ -139,6 +140,14 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
         <div class="graph-tabs" role="tablist" aria-label="Graph views">
           <button id="graph-world-tab" class="graph-tab active" type="button" role="tab">World Graph</button>
           <button id="graph-logic-tab" class="graph-tab" type="button" role="tab">Logic Graph</button>
+          <div id="graph-world-mode" class="graph-world-mode" aria-label="World graph mode">
+            <button id="graph-world-raw" class="graph-mode-button active" type="button">Raw</button>
+            <button id="graph-world-folded" class="graph-mode-button" type="button">Folded</button>
+          </div>
+          <label class="graph-tag-toggle">
+            <input id="graph-show-tags" type="checkbox" checked />
+            <span>Show Tag</span>
+          </label>
           <div class="graph-zoom-controls" aria-label="Graph zoom">
             <button id="graph-zoom-out" class="graph-zoom-button" type="button" aria-label="Zoom out">-</button>
             <button id="graph-zoom-reset" class="graph-zoom-value" type="button" aria-label="Reset zoom">100%</button>
@@ -186,6 +195,10 @@ const closeGraphsButton = document.querySelector<HTMLButtonElement>('#close-grap
 const graphDialog = document.querySelector<HTMLDialogElement>('#graph-dialog')!;
 const graphWorldTab = document.querySelector<HTMLButtonElement>('#graph-world-tab')!;
 const graphLogicTab = document.querySelector<HTMLButtonElement>('#graph-logic-tab')!;
+const graphWorldMode = document.querySelector<HTMLElement>('#graph-world-mode')!;
+const graphWorldRawButton = document.querySelector<HTMLButtonElement>('#graph-world-raw')!;
+const graphWorldFoldedButton = document.querySelector<HTMLButtonElement>('#graph-world-folded')!;
+const graphShowTagsInput = document.querySelector<HTMLInputElement>('#graph-show-tags')!;
 const graphZoomOutButton = document.querySelector<HTMLButtonElement>('#graph-zoom-out')!;
 const graphZoomResetButton = document.querySelector<HTMLButtonElement>('#graph-zoom-reset')!;
 const graphZoomInButton = document.querySelector<HTMLButtonElement>('#graph-zoom-in')!;
@@ -211,6 +224,8 @@ let traceAnimation: TraceAnimation | undefined;
 let traceAnimationToken = 0;
 let graphDot: GraphDotInfo | undefined;
 let graphTab: GraphTab = 'world';
+let graphWorldModeValue: GraphWorldMode = 'raw';
+let graphShowTags = true;
 let vizPromise: Promise<Viz> | undefined;
 let graphMinimapScale = 1;
 let isDraggingGraphMinimap = false;
@@ -287,6 +302,19 @@ graphLogicTab.addEventListener('click', () => {
   void setGraphTab('logic');
 });
 
+graphWorldRawButton.addEventListener('click', () => {
+  void setGraphWorldMode('raw');
+});
+
+graphWorldFoldedButton.addEventListener('click', () => {
+  void setGraphWorldMode('folded');
+});
+
+graphShowTagsInput.addEventListener('change', () => {
+  graphShowTags = graphShowTagsInput.checked;
+  void renderGraphTab();
+});
+
 graphZoomOutButton.addEventListener('click', () => {
   setGraphZoom(graphZoom - 0.25);
 });
@@ -358,6 +386,14 @@ async function setGraphTab(nextTab: GraphTab): Promise<void> {
   await renderGraphTab();
 }
 
+async function setGraphWorldMode(nextMode: GraphWorldMode): Promise<void> {
+  graphWorldModeValue = nextMode;
+  updateGraphTabs();
+  if (graphTab === 'world') {
+    await renderGraphTab();
+  }
+}
+
 async function renderGraphTab(): Promise<void> {
   updateGraphTabs();
   graphOutput.replaceChildren();
@@ -368,10 +404,15 @@ async function renderGraphTab(): Promise<void> {
     return;
   }
 
-  graphStatus.textContent = graphTab === 'logic' ? 'Logic Graph' : 'World Graph';
+  graphStatus.textContent =
+    graphTab === 'logic'
+      ? 'Logic Graph'
+      : graphWorldModeValue === 'folded'
+        ? 'World Graph - Folded'
+        : 'World Graph - Raw';
 
   try {
-    const dot = graphTab === 'logic' ? graphDot.logicDot : graphDot.worldDot;
+    const dot = currentGraphDot();
     const viz = await loadViz();
     const svg = viz.renderSVGElement(dot, { engine: 'dot' });
     graphOutput.append(svg);
@@ -380,6 +421,20 @@ async function renderGraphTab(): Promise<void> {
   } catch (error) {
     graphStatus.textContent = error instanceof Error ? error.message : String(error);
   }
+}
+
+function currentGraphDot(): string {
+  if (!graphDot) return '';
+
+  if (graphTab === 'logic') {
+    return graphShowTags ? graphDot.logicDot : graphDot.logicDotWithoutTags;
+  }
+
+  if (graphWorldModeValue === 'folded') {
+    return graphShowTags ? graphDot.foldedWorldDot : graphDot.foldedWorldDotWithoutTags;
+  }
+
+  return graphShowTags ? graphDot.rawWorldDot : graphDot.rawWorldDotWithoutTags;
 }
 
 async function loadViz(): Promise<Viz> {
@@ -488,6 +543,11 @@ function updateGraphTabs(): void {
     button.classList.toggle('active', active);
     button.setAttribute('aria-selected', String(active));
   }
+
+  graphWorldMode.classList.toggle('hidden', graphTab !== 'world');
+  graphWorldRawButton.classList.toggle('active', graphWorldModeValue === 'raw');
+  graphWorldFoldedButton.classList.toggle('active', graphWorldModeValue === 'folded');
+  graphShowTagsInput.checked = graphShowTags;
 }
 
 async function toggleSelectedSwitch(): Promise<void> {
@@ -796,6 +856,7 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
     currentRoot = parsed.root;
     graphDot = undefined;
     graphTab = 'world';
+    graphWorldModeValue = 'raw';
 
     markSelectedFile(selectedEntry);
 
@@ -821,6 +882,7 @@ async function openFile(file: File, selectedEntry?: Element | null): Promise<voi
     currentRoot = undefined;
     graphDot = undefined;
     graphTab = 'world';
+    graphWorldModeValue = 'raw';
     selectedBlock = undefined;
     toggleSwitchButton.classList.add('hidden');
     viewerEmpty.classList.remove('hidden');

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -64,6 +64,11 @@ type ExampleFile = {
 };
 
 const TRACE_ANIMATION_INTERVAL_MS = 50;
+const GRAPH_MINIMAP_INSET = 0;
+const GRAPH_MINIMAP_MAX_WIDTH = 360;
+const GRAPH_MINIMAP_MAX_HEIGHT = 240;
+const GRAPH_MINIMAP_MIN_WIDTH = 150;
+const GRAPH_MINIMAP_MIN_HEIGHT = 48;
 
 function resolveAssetPath(path: string): string {
   return new URL(`${import.meta.env.BASE_URL}${path}`, window.location.origin).href;
@@ -331,6 +336,17 @@ graphOutput.addEventListener('scroll', () => {
   updateGraphMinimapViewport();
 });
 
+graphOutput.addEventListener(
+  'wheel',
+  event => {
+    if (!event.ctrlKey) return;
+
+    event.preventDefault();
+    zoomGraphAt(event.clientX, event.clientY, graphZoom * (event.deltaY < 0 ? 1.12 : 1 / 1.12));
+  },
+  { passive: false },
+);
+
 graphMinimap.addEventListener('pointerdown', event => {
   if (graphMinimap.classList.contains('hidden')) return;
 
@@ -447,6 +463,22 @@ function setGraphZoom(nextZoom: number): void {
   applyGraphZoom({ refreshMinimap: true });
 }
 
+function zoomGraphAt(clientX: number, clientY: number, nextZoom: number): void {
+  const previousZoom = graphZoom;
+  const clampedZoom = Math.max(0.25, Math.min(3, nextZoom));
+  if (clampedZoom === previousZoom) return;
+
+  const outputRect = graphOutput.getBoundingClientRect();
+  const focusX = graphOutput.scrollLeft + clientX - outputRect.left;
+  const focusY = graphOutput.scrollTop + clientY - outputRect.top;
+  graphZoom = clampedZoom;
+  applyGraphZoom({ refreshMinimap: true });
+
+  const ratio = clampedZoom / previousZoom;
+  graphOutput.scrollLeft = focusX * ratio - (clientX - outputRect.left);
+  graphOutput.scrollTop = focusY * ratio - (clientY - outputRect.top);
+}
+
 function applyGraphZoom(options: { refreshMinimap?: boolean } = {}): void {
   graphZoomResetButton.textContent = `${Math.round(graphZoom * 100)}%`;
   graphZoomOutButton.disabled = graphZoom <= 0.25;
@@ -490,37 +522,60 @@ function renderGraphMinimap(svg: SVGSVGElement): void {
   graphMinimap.classList.remove('hidden');
 
   requestAnimationFrame(() => {
-    const contentWidth = Math.max(graphOutput.scrollWidth, 1);
-    const contentHeight = Math.max(graphOutput.scrollHeight, 1);
-    const minimapWidth = graphMinimapContent.clientWidth;
-    const minimapHeight = graphMinimapContent.clientHeight;
-    graphMinimapScale = Math.min(minimapWidth / contentWidth, minimapHeight / contentHeight);
+    const graphRect = currentGraphRect(svg);
+    if (!graphRect) {
+      clearGraphMinimap();
+      return;
+    }
 
-    clone.style.width = `${contentWidth * graphMinimapScale}px`;
-    clone.style.height = `${contentHeight * graphMinimapScale}px`;
+    sizeGraphMinimap(graphRect.width, graphRect.height);
+
+    const minimapWidth = Math.max(graphMinimapContent.clientWidth, 1);
+    const minimapHeight = Math.max(graphMinimapContent.clientHeight, 1);
+    graphMinimapScale = Math.min(minimapWidth / graphRect.width, minimapHeight / graphRect.height);
+
+    const fittedWidth = graphRect.width * graphMinimapScale;
+    const fittedHeight = graphRect.height * graphMinimapScale;
+    graphMinimap.style.width = `${fittedWidth + GRAPH_MINIMAP_INSET * 2 + 2}px`;
+    graphMinimap.style.height = `${fittedHeight + GRAPH_MINIMAP_INSET * 2 + 2}px`;
+    clone.style.width = `${fittedWidth}px`;
+    clone.style.height = `${fittedHeight}px`;
     updateGraphMinimapViewport();
   });
 }
 
 function updateGraphMinimapViewport(): void {
   if (graphMinimap.classList.contains('hidden')) return;
+  const svg = graphOutput.querySelector<SVGSVGElement>('svg');
+  const graphRect = svg ? currentGraphRect(svg) : undefined;
+  if (!graphRect) return;
 
-  graphMinimapViewport.style.width = `${graphOutput.clientWidth * graphMinimapScale}px`;
-  graphMinimapViewport.style.height = `${graphOutput.clientHeight * graphMinimapScale}px`;
-  graphMinimapViewport.style.transform = `translate(${graphOutput.scrollLeft * graphMinimapScale}px, ${
-    graphOutput.scrollTop * graphMinimapScale
+  const visibleLeft = Math.max(0, graphOutput.scrollLeft - graphRect.left);
+  const visibleTop = Math.max(0, graphOutput.scrollTop - graphRect.top);
+  const visibleRight = Math.min(graphRect.width, graphOutput.scrollLeft + graphOutput.clientWidth - graphRect.left);
+  const visibleBottom = Math.min(graphRect.height, graphOutput.scrollTop + graphOutput.clientHeight - graphRect.top);
+  const visibleWidth = Math.max(0, visibleRight - visibleLeft);
+  const visibleHeight = Math.max(0, visibleBottom - visibleTop);
+
+  graphMinimapViewport.style.width = `${visibleWidth * graphMinimapScale}px`;
+  graphMinimapViewport.style.height = `${visibleHeight * graphMinimapScale}px`;
+  graphMinimapViewport.style.transform = `translate(${visibleLeft * graphMinimapScale}px, ${
+    visibleTop * graphMinimapScale
   }px)`;
 }
 
 function scrollGraphFromMinimap(event: PointerEvent): void {
   event.preventDefault();
   if (graphMinimapScale <= 0) return;
+  const svg = graphOutput.querySelector<SVGSVGElement>('svg');
+  const graphRect = svg ? currentGraphRect(svg) : undefined;
+  if (!graphRect) return;
 
   const minimapContentBox = graphMinimapContent.getBoundingClientRect();
   const x = Math.max(0, Math.min(minimapContentBox.width, event.clientX - minimapContentBox.left));
   const y = Math.max(0, Math.min(minimapContentBox.height, event.clientY - minimapContentBox.top));
-  graphOutput.scrollLeft = x / graphMinimapScale - graphOutput.clientWidth / 2;
-  graphOutput.scrollTop = y / graphMinimapScale - graphOutput.clientHeight / 2;
+  graphOutput.scrollLeft = graphRect.left + x / graphMinimapScale - graphOutput.clientWidth / 2;
+  graphOutput.scrollTop = graphRect.top + y / graphMinimapScale - graphOutput.clientHeight / 2;
   updateGraphMinimapViewport();
 }
 
@@ -528,8 +583,46 @@ function clearGraphMinimap(): void {
   graphMinimap.classList.add('hidden');
   graphMinimapContent.replaceChildren();
   graphMinimapViewport.removeAttribute('style');
+  graphMinimap.removeAttribute('style');
   graphMinimapScale = 1;
   isDraggingGraphMinimap = false;
+}
+
+function currentGraphRect(svg: SVGSVGElement): { left: number; top: number; width: number; height: number } | undefined {
+  const width = readGraphBaseSize(svg, 'width') * graphZoom;
+  const height = readGraphBaseSize(svg, 'height') * graphZoom;
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return undefined;
+  }
+
+  const outputRect = graphOutput.getBoundingClientRect();
+  const svgRect = svg.getBoundingClientRect();
+
+  return {
+    left: svgRect.left - outputRect.left + graphOutput.scrollLeft,
+    top: svgRect.top - outputRect.top + graphOutput.scrollTop,
+    width,
+    height,
+  };
+}
+
+function sizeGraphMinimap(contentWidth: number, contentHeight: number): void {
+  const aspect = Math.max(contentWidth / Math.max(contentHeight, 1), 0.1);
+  const maxContentWidth = Math.min(GRAPH_MINIMAP_MAX_WIDTH, Math.max(GRAPH_MINIMAP_MIN_WIDTH, graphOutput.clientWidth * 0.28));
+  const maxContentHeight = Math.min(
+    GRAPH_MINIMAP_MAX_HEIGHT,
+    Math.max(GRAPH_MINIMAP_MIN_HEIGHT, graphOutput.clientHeight * 0.28),
+  );
+
+  let minimapContentWidth = maxContentWidth;
+  let minimapContentHeight = minimapContentWidth / aspect;
+  if (minimapContentHeight > maxContentHeight) {
+    minimapContentHeight = maxContentHeight;
+    minimapContentWidth = minimapContentHeight * aspect;
+  }
+
+  graphMinimap.style.width = `${Math.max(GRAPH_MINIMAP_MIN_WIDTH, minimapContentWidth) + GRAPH_MINIMAP_INSET * 2}px`;
+  graphMinimap.style.height = `${Math.max(GRAPH_MINIMAP_MIN_HEIGHT, minimapContentHeight) + GRAPH_MINIMAP_INSET * 2}px`;
 }
 
 function updateGraphTabs(): void {

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -57,6 +57,11 @@ type TraceAnimation = {
 };
 type GraphTab = 'world' | 'logic';
 type GraphWorldMode = 'raw' | 'folded';
+type GraphEdgeInfo = {
+  element: SVGGElement;
+  source: string;
+  target: string;
+};
 type ExampleFile = {
   name: string;
   path: string;
@@ -235,6 +240,7 @@ let vizPromise: Promise<Viz> | undefined;
 let graphMinimapScale = 1;
 let isDraggingGraphMinimap = false;
 let graphZoom = 1;
+let selectedGraphNode: string | undefined;
 
 folderInput.setAttribute('webkitdirectory', '');
 folderInput.setAttribute('directory', '');
@@ -431,7 +437,10 @@ async function renderGraphTab(): Promise<void> {
     const dot = currentGraphDot();
     const viz = await loadViz();
     const svg = viz.renderSVGElement(dot, { engine: 'dot' });
+    selectedGraphNode = undefined;
     graphOutput.append(svg);
+    installGraphNodeHitAreas(svg);
+    bindGraphSelection(svg);
     applyGraphZoom();
     renderGraphMinimap(svg);
   } catch (error) {
@@ -451,6 +460,139 @@ function currentGraphDot(): string {
   }
 
   return graphShowTags ? graphDot.rawWorldDot : graphDot.rawWorldDotWithoutTags;
+}
+
+function installGraphNodeHitAreas(svg: SVGSVGElement): void {
+  svg.querySelectorAll<SVGGElement>('g.node').forEach(node => {
+    node.querySelector(':scope > .graph-node-hit-area')?.remove();
+    const bbox = node.getBBox();
+    if (!bbox) return;
+
+    const hitArea = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    hitArea.classList.add('graph-node-hit-area');
+    hitArea.setAttribute('x', String(bbox.x));
+    hitArea.setAttribute('y', String(bbox.y));
+    hitArea.setAttribute('width', String(bbox.width));
+    hitArea.setAttribute('height', String(bbox.height));
+    node.prepend(hitArea);
+  });
+}
+
+function bindGraphSelection(svg: SVGSVGElement): void {
+  svg.addEventListener('click', event => {
+    const target = event.target;
+    if (!(target instanceof Element)) return;
+
+    const node = target.closest<SVGGElement>('g.node');
+    if (!node || !svg.contains(node)) {
+      selectedGraphNode = undefined;
+      applyGraphSelection(svg);
+      updateGraphSelectionStatus();
+      return;
+    }
+
+    const nodeId = graphElementTitle(node);
+    if (!nodeId) return;
+    selectedGraphNode = selectedGraphNode === nodeId ? undefined : nodeId;
+    applyGraphSelection(svg);
+    updateGraphSelectionStatus();
+  });
+}
+
+function applyGraphSelection(svg: SVGSVGElement): void {
+  const nodeElements = graphNodeElements(svg);
+  const edgeElements = graphEdgeElements(svg);
+  const selectedNodes = new Set<string>();
+  const connectedEdges = new Set<SVGGElement>();
+
+  if (selectedGraphNode) {
+    const directionalSelection = collectDirectionalGraphSelection(selectedGraphNode, edgeElements);
+    directionalSelection.nodes.forEach(nodeId => selectedNodes.add(nodeId));
+    directionalSelection.edges.forEach(edge => connectedEdges.add(edge));
+  }
+
+  svg.classList.toggle('graph-has-selection', Boolean(selectedGraphNode));
+  for (const [nodeId, node] of nodeElements) {
+    node.classList.toggle('graph-node-selected', selectedNodes.has(nodeId));
+    node.classList.toggle('graph-node-root', selectedGraphNode === nodeId);
+    node.classList.toggle('graph-node-dimmed', Boolean(selectedGraphNode) && !selectedNodes.has(nodeId));
+  }
+
+  for (const edge of edgeElements) {
+    edge.element.classList.toggle('graph-edge-connected', connectedEdges.has(edge.element));
+    edge.element.classList.toggle('graph-edge-dimmed', Boolean(selectedGraphNode) && !connectedEdges.has(edge.element));
+  }
+}
+
+function collectDirectionalGraphSelection(root: string, edges: GraphEdgeInfo[]): { nodes: Set<string>; edges: Set<SVGGElement> } {
+  const nodes = new Set<string>([root]);
+  const selectedEdges = new Set<SVGGElement>();
+
+  collectGraphCone(root, edges, 'incoming', nodes, selectedEdges);
+  collectGraphCone(root, edges, 'outgoing', nodes, selectedEdges);
+
+  return { nodes, edges: selectedEdges };
+}
+
+function collectGraphCone(
+  root: string,
+  edges: GraphEdgeInfo[],
+  direction: 'incoming' | 'outgoing',
+  nodes: Set<string>,
+  selectedEdges: Set<SVGGElement>,
+): void {
+  const visited = new Set<string>();
+  const queue = [root];
+
+  while (queue.length > 0) {
+    const nodeId = queue.pop()!;
+    if (!visited.add(nodeId)) continue;
+
+    for (const edge of edges) {
+      const next = direction === 'incoming' && edge.target === nodeId ? edge.source : direction === 'outgoing' && edge.source === nodeId ? edge.target : undefined;
+      if (!next) continue;
+
+      nodes.add(next);
+      selectedEdges.add(edge.element);
+      if (!visited.has(next)) queue.push(next);
+    }
+  }
+}
+
+function updateGraphSelectionStatus(): void {
+  const title =
+    graphTab === 'logic'
+      ? 'Logic Graph'
+      : graphWorldModeValue === 'folded'
+        ? 'World Graph - Folded'
+        : 'World Graph - Raw';
+  graphStatus.textContent = selectedGraphNode ? `${title} - ${selectedGraphNode} selected` : title;
+}
+
+function graphNodeElements(svg: SVGSVGElement): Map<string, SVGGElement> {
+  const nodes = new Map<string, SVGGElement>();
+  svg.querySelectorAll<SVGGElement>('g.node').forEach(node => {
+    const nodeId = graphElementTitle(node);
+    if (nodeId) nodes.set(nodeId, node);
+  });
+  return nodes;
+}
+
+function graphEdgeElements(svg: SVGSVGElement): GraphEdgeInfo[] {
+  return Array.from(svg.querySelectorAll<SVGGElement>('g.edge')).flatMap(edge => {
+    const parsed = parseGraphEdgeTitle(graphElementTitle(edge));
+    return parsed ? [{ element: edge, ...parsed }] : [];
+  });
+}
+
+function graphElementTitle(element: Element): string | undefined {
+  return element.querySelector(':scope > title')?.textContent?.trim() || undefined;
+}
+
+function parseGraphEdgeTitle(title: string | undefined): { source: string; target: string } | undefined {
+  const match = title?.match(/^(node\d+)(?::[^-]+)?->(node\d+)(?::.+)?$/);
+  if (!match) return undefined;
+  return { source: match[1], target: match[2] };
 }
 
 async function loadViz(): Promise<Viz> {
@@ -518,6 +660,7 @@ function readGraphBaseSize(svg: SVGSVGElement, dimension: 'width' | 'height'): n
 function renderGraphMinimap(svg: SVGSVGElement): void {
   graphMinimapContent.replaceChildren();
   const clone = svg.cloneNode(true) as SVGSVGElement;
+  clone.querySelectorAll('.graph-node-hit-area').forEach(hitArea => hitArea.remove());
   graphMinimapContent.append(clone);
   graphMinimap.classList.remove('hidden');
 

--- a/tools/nbt-viewer/src/sim/NbtSimulation.ts
+++ b/tools/nbt-viewer/src/sim/NbtSimulation.ts
@@ -46,13 +46,21 @@ export type SnapshotInfo = {
 };
 
 type RawGraphDotInfo = {
-  world_dot: string;
+  raw_world_dot: string;
+  raw_world_dot_without_tags: string;
+  folded_world_dot: string;
+  folded_world_dot_without_tags: string;
   logic_dot: string;
+  logic_dot_without_tags: string;
 };
 
 export type GraphDotInfo = {
-  worldDot: string;
+  rawWorldDot: string;
+  rawWorldDotWithoutTags: string;
+  foldedWorldDot: string;
+  foldedWorldDotWithoutTags: string;
   logicDot: string;
+  logicDotWithoutTags: string;
 };
 
 export class NbtSimulationError extends Error {
@@ -93,8 +101,12 @@ export class NbtSimulation {
     const graphDot = wasm.NbtSimulator.graph_dot(nbtBytes);
 
     return {
-      worldDot: graphDot.world_dot,
+      rawWorldDot: graphDot.raw_world_dot,
+      rawWorldDotWithoutTags: graphDot.raw_world_dot_without_tags,
+      foldedWorldDot: graphDot.folded_world_dot,
+      foldedWorldDotWithoutTags: graphDot.folded_world_dot_without_tags,
       logicDot: graphDot.logic_dot,
+      logicDotWithoutTags: graphDot.logic_dot_without_tags,
     };
   }
 

--- a/tools/nbt-viewer/src/sim/NbtSimulation.ts
+++ b/tools/nbt-viewer/src/sim/NbtSimulation.ts
@@ -5,6 +5,8 @@ type WasmModule = {
   NbtSimulator: {
     new (nbtBytes: Uint8Array): WasmSimulator;
     graph_dot(nbtBytes: Uint8Array): RawGraphDotInfo;
+    selected_graph_dot(nbtBytes: Uint8Array, folded: boolean, nodeIds: number[]): RawGraphDotInfo;
+    selected_nbt(nbtBytes: Uint8Array, folded: boolean, nodeIds: number[]): unknown;
     trace_init(nbtBytes: Uint8Array): TraceReport;
   };
 };
@@ -100,14 +102,22 @@ export class NbtSimulation {
     await wasm.default(resolveAssetPath(wasmBinaryPath));
     const graphDot = wasm.NbtSimulator.graph_dot(nbtBytes);
 
-    return {
-      rawWorldDot: graphDot.raw_world_dot,
-      rawWorldDotWithoutTags: graphDot.raw_world_dot_without_tags,
-      foldedWorldDot: graphDot.folded_world_dot,
-      foldedWorldDotWithoutTags: graphDot.folded_world_dot_without_tags,
-      logicDot: graphDot.logic_dot,
-      logicDotWithoutTags: graphDot.logic_dot_without_tags,
-    };
+    return mapGraphDotInfo(graphDot);
+  }
+
+  static async selectedGraphDot(nbtBytes: Uint8Array, folded: boolean, nodeIds: number[]): Promise<GraphDotInfo> {
+    const wasm = await loadWasmModule();
+    await wasm.default(resolveAssetPath(wasmBinaryPath));
+    const graphDot = wasm.NbtSimulator.selected_graph_dot(nbtBytes, folded, nodeIds);
+
+    return mapGraphDotInfo(graphDot);
+  }
+
+  static async selectedNbt(nbtBytes: Uint8Array, folded: boolean, nodeIds: number[]): Promise<unknown> {
+    const wasm = await loadWasmModule();
+    await wasm.default(resolveAssetPath(wasmBinaryPath));
+
+    return wasm.NbtSimulator.selected_nbt(nbtBytes, folded, nodeIds);
   }
 
   static async create(nbtBytes: Uint8Array): Promise<NbtSimulation> {
@@ -159,6 +169,17 @@ export class NbtSimulation {
       throw new NbtSimulationError(getErrorMessage(error), this.trace(), this.snapshots());
     }
   }
+}
+
+function mapGraphDotInfo(graphDot: RawGraphDotInfo): GraphDotInfo {
+  return {
+    rawWorldDot: graphDot.raw_world_dot,
+    rawWorldDotWithoutTags: graphDot.raw_world_dot_without_tags,
+    foldedWorldDot: graphDot.folded_world_dot,
+    foldedWorldDotWithoutTags: graphDot.folded_world_dot_without_tags,
+    logicDot: graphDot.logic_dot,
+    logicDotWithoutTags: graphDot.logic_dot_without_tags,
+  };
 }
 
 function getErrorMessage(error: unknown): string {

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -508,6 +508,61 @@ input {
   color: #fff;
 }
 
+.graph-world-mode {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  min-height: 28px;
+  margin-left: 8px;
+  padding: 2px;
+  border: 1px solid rgb(154 164 173 / 24%);
+  border-radius: 5px;
+  background: rgb(10 13 16 / 42%);
+}
+
+.graph-world-mode.hidden {
+  display: none;
+}
+
+.graph-mode-button {
+  min-width: 54px;
+  height: 22px;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: #aeb8c0;
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.graph-mode-button:hover,
+.graph-mode-button.active {
+  background: rgb(255 255 255 / 12%);
+  color: #fff;
+}
+
+.graph-tag-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 28px;
+  margin-left: 4px;
+  padding: 0 8px;
+  border: 1px solid rgb(154 164 173 / 24%);
+  border-radius: 5px;
+  background: rgb(10 13 16 / 30%);
+  color: #cbd4db;
+  cursor: pointer;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.graph-tag-toggle input {
+  width: 14px;
+  height: 14px;
+  accent-color: #d33232;
+}
+
 .graph-zoom-controls {
   display: flex;
   align-items: center;

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -628,7 +628,7 @@ input {
 .graph-output svg {
   display: block;
   max-width: none;
-  margin: 18px;
+  margin: 0;
 }
 
 .graph-minimap {
@@ -657,7 +657,7 @@ input {
 
 .graph-minimap-content {
   position: absolute;
-  inset: 8px;
+  inset: 0;
   overflow: hidden;
 }
 
@@ -669,8 +669,8 @@ input {
 
 .graph-minimap-viewport {
   position: absolute;
-  left: 8px;
-  top: 8px;
+  left: 0;
+  top: 0;
   min-width: 8px;
   min-height: 8px;
   border: 2px solid #d33232;

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -631,6 +631,55 @@ input {
   margin: 0;
 }
 
+.graph-selection-actions {
+  position: absolute;
+  right: 14px;
+  top: 14px;
+  z-index: 2;
+  display: flex;
+  gap: 8px;
+}
+
+.graph-selection-actions.hidden {
+  display: none;
+}
+
+.graph-selection-button {
+  height: 30px;
+  padding: 0 10px;
+  border: 1px solid rgb(17 24 32 / 28%);
+  border-radius: 5px;
+  background: rgb(247 249 251 / 92%);
+  color: #111820;
+  cursor: pointer;
+  font-size: 12px;
+  box-shadow: 0 12px 34px rgb(0 0 0 / 20%);
+}
+
+.graph-selection-button:hover {
+  background: #fff;
+}
+
+.graph-viewer.has-selection-action .graph-minimap {
+  bottom: 14px;
+}
+
+.selected-nbt-dialog-surface {
+  grid-template-rows: auto auto 1fr;
+}
+
+.selected-nbt-viewer {
+  position: relative;
+  min-height: 0;
+  background: #101317;
+}
+
+#selected-nbt-canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
 .graph-output svg g.node {
   cursor: pointer;
 }

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -631,6 +631,41 @@ input {
   margin: 0;
 }
 
+.graph-output svg g.node {
+  cursor: pointer;
+}
+
+.graph-output svg .graph-node-hit-area {
+  fill: transparent;
+  pointer-events: all;
+}
+
+.graph-output svg.graph-has-selection g.node.graph-node-dimmed {
+  opacity: 0.48;
+}
+
+.graph-output svg.graph-has-selection g.edge.graph-edge-dimmed {
+  opacity: 0.32;
+}
+
+.graph-output svg g.node.graph-node-selected polygon,
+.graph-output svg g.node.graph-node-selected path,
+.graph-output svg g.node.graph-node-selected ellipse {
+  filter: drop-shadow(0 0 4px rgb(209 83 28 / 30%));
+  stroke: #d1531c;
+  stroke-width: 1.5;
+}
+
+.graph-output svg g.edge.graph-edge-connected path {
+  stroke: #d1531c;
+  stroke-width: 1.5;
+}
+
+.graph-output svg g.edge.graph-edge-connected polygon {
+  fill: #d1531c;
+  stroke: #d1531c;
+}
+
 .graph-minimap {
   position: absolute;
   right: 14px;


### PR DESCRIPTION
## Summary
- fold RS latch feedback SCCs before logic graph extraction so latch NBT examples render
- expose raw/folded world graph views with tag toggles in the NBT viewer
- improve graph minimap, ctrl-wheel zoom, and dependency-cone selection highlighting
- add selected graph and selected NBT dialogs, including support/routed blocks for extracted NBT views

## Verification
- cargo test --release
- npm.cmd run build:wasm
- npm.cmd run build
- browser verification on http://localhost:5174/