### PR TITLE
Add nbt viewer trace toggle

### DIFF
--- a/crates/nbt-sim-wasm/src/lib.rs
+++ b/crates/nbt-sim-wasm/src/lib.rs
@@ -64,6 +64,43 @@ pub struct NbtSimulator {
 }
 
 impl NbtSimulator {
+    fn new_with_trace_limit(nbt_bytes: &[u8], trace_limit: usize) -> Result<NbtSimulator, JsValue> {
+        let nbt = NBTRoot::from_nbt_bytes(nbt_bytes).map_err(to_js_error)?;
+        let world = nbt.to_world();
+        let sim = Simulator::from_preserving_torch_states_with_limits_and_trace(
+            &world,
+            MAX_SIMULATION_CYCLES,
+            MAX_SIMULATION_EVENTS,
+            trace_limit,
+        )
+        .map_err(to_js_error)?;
+        let last_trace = sim.trace().to_vec();
+        let last_snapshots = snapshots_to_info(sim.snapshots());
+        let last_waveform = sim.waveform();
+        let history_trace = sim.trace().to_vec();
+        let history_snapshots = snapshots_to_info(sim.snapshots());
+        let history_waveform = sim.waveform();
+
+        Ok(Self {
+            sim,
+            last_trace,
+            last_snapshots,
+            last_waveform,
+            history_trace,
+            history_snapshots,
+            history_waveform,
+        })
+    }
+
+    fn clear_trace_views(&mut self) {
+        self.last_trace.clear();
+        self.last_snapshots.clear();
+        self.last_waveform = empty_waveform();
+        self.history_trace.clear();
+        self.history_snapshots.clear();
+        self.history_waveform = empty_waveform();
+    }
+
     fn refresh_trace_views_from_cycle(&mut self, start_cycle: usize) {
         let trace = self.sim.trace();
         let snapshots = self.sim.snapshots();
@@ -90,31 +127,14 @@ impl NbtSimulator {
 impl NbtSimulator {
     #[wasm_bindgen(constructor)]
     pub fn new(nbt_bytes: &[u8]) -> Result<NbtSimulator, JsValue> {
-        let nbt = NBTRoot::from_nbt_bytes(nbt_bytes).map_err(to_js_error)?;
-        let world = nbt.to_world();
-        let sim = Simulator::from_preserving_torch_states_with_limits_and_trace(
-            &world,
-            MAX_SIMULATION_CYCLES,
-            MAX_SIMULATION_EVENTS,
-            TRACE_LIMIT,
-        )
-        .map_err(to_js_error)?;
-        let last_trace = sim.trace().to_vec();
-        let last_snapshots = snapshots_to_info(sim.snapshots());
-        let last_waveform = sim.waveform();
-        let history_trace = sim.trace().to_vec();
-        let history_snapshots = snapshots_to_info(sim.snapshots());
-        let history_waveform = sim.waveform();
+        Self::new_with_trace_limit(nbt_bytes, TRACE_LIMIT)
+    }
 
-        Ok(Self {
-            sim,
-            last_trace,
-            last_snapshots,
-            last_waveform,
-            history_trace,
-            history_snapshots,
-            history_waveform,
-        })
+    pub fn with_trace(nbt_bytes: &[u8], trace_enabled: bool) -> Result<NbtSimulator, JsValue> {
+        Self::new_with_trace_limit(
+            nbt_bytes,
+            if trace_enabled { TRACE_LIMIT } else { 0 },
+        )
     }
 
     pub fn trace_init(nbt_bytes: &[u8]) -> Result<JsValue, JsValue> {
@@ -269,6 +289,12 @@ impl NbtSimulator {
         self.structure()
     }
 
+    pub fn set_trace_enabled(&mut self, enabled: bool) {
+        self.sim
+            .set_trace_limit(if enabled { TRACE_LIMIT } else { 0 });
+        self.clear_trace_views();
+    }
+
     pub fn trace(&self) -> Result<JsValue, JsValue> {
         serde_wasm_bindgen::to_value(&self.last_trace).map_err(to_js_error)
     }
@@ -309,6 +335,13 @@ impl NbtSimulator {
 
 fn to_js_error(error: impl std::fmt::Display) -> JsValue {
     JsValue::from_str(&error.to_string())
+}
+
+fn empty_waveform() -> SimulationWaveform {
+    SimulationWaveform {
+        cycles: Vec::new(),
+        signals: Vec::new(),
+    }
 }
 
 fn graph_dot_info(nbt_bytes: &[u8], metadata: Option<&OutputMetadata>) -> Result<JsValue, JsValue> {

--- a/src/world/simulator.rs
+++ b/src/world/simulator.rs
@@ -554,6 +554,13 @@ impl Simulator {
         self.snapshots.clear();
     }
 
+    pub fn set_trace_limit(&mut self, trace_limit: usize) {
+        self.trace_limit = trace_limit;
+        if trace_limit == 0 {
+            self.clear_trace();
+        }
+    }
+
     pub fn run(&mut self) -> eyre::Result<usize> {
         self.run_inner(SimulationLimits::cycles(None))
     }
@@ -2225,6 +2232,44 @@ mod test {
         assert_eq!(waveform.signals[2].values, vec![0, 1]);
         assert_eq!(waveform.signals[3].position, [3, 0, 0]);
         assert_eq!(waveform.signals[3].values, vec![1, 0]);
+    }
+
+    #[test]
+    fn unittest_simulator_can_reenable_trace_after_running_without_trace() -> eyre::Result<()> {
+        let default_redstone = Block {
+            kind: BlockKind::Redstone {
+                on_count: 0,
+                state: 0,
+                strength: 0,
+            },
+            direction: Direction::None,
+        };
+        let world = World {
+            size: DimSize(3, 1, 1),
+            blocks: vec![
+                (
+                    Position(0, 0, 0),
+                    Block {
+                        kind: BlockKind::Switch { is_on: false },
+                        direction: Direction::Top,
+                    },
+                ),
+                (Position(1, 0, 0), default_redstone),
+            ],
+        };
+        let mut sim = Simulator::from_with_limits_and_trace(&world, 16, 100, 0)
+            .map_err(|error| eyre::eyre!(error.message().to_owned()))?;
+
+        sim.change_state_with_limits(vec![(Position(0, 0, 0), true)], 16, 100)?;
+        assert!(sim.trace().is_empty());
+        assert!(sim.snapshots().is_empty());
+
+        sim.set_trace_limit(50_000);
+        sim.change_state_with_limits(vec![(Position(0, 0, 0), false)], 16, 100)?;
+
+        assert!(!sim.trace().is_empty());
+        assert!(!sim.snapshots().is_empty());
+        Ok(())
     }
 
     fn assert_matches_fresh_recompute(

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -115,7 +115,10 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
             <button id="switches-all-off" type="button">All Off</button>
             <label id="trace-simulation-toggle" class="trace-simulation-toggle active" title="Collect trace and waveform data while switches simulate">
               <input id="trace-simulation-enabled" type="checkbox" checked />
-              <span>Trace</span>
+              <span class="trace-simulation-label">Trace</span>
+              <span class="trace-simulation-track" aria-hidden="true">
+                <span class="trace-simulation-knob"></span>
+              </span>
               <strong id="trace-simulation-state">On</strong>
             </label>
           </div>

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -113,6 +113,11 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
           <div id="switches-actions" class="switches-actions hidden">
             <button id="switches-all-on" type="button">All On</button>
             <button id="switches-all-off" type="button">All Off</button>
+            <label id="trace-simulation-toggle" class="trace-simulation-toggle active" title="Collect trace and waveform data while switches simulate">
+              <input id="trace-simulation-enabled" type="checkbox" checked />
+              <span>Trace</span>
+              <strong id="trace-simulation-state">On</strong>
+            </label>
           </div>
           <div id="switches-list" class="switches-list empty">Open an NBT file to control switches.</div>
         </details>
@@ -280,6 +285,9 @@ const switchesAllOnButton = document.querySelector<HTMLButtonElement>('#switches
 const switchesAllOffButton = document.querySelector<HTMLButtonElement>('#switches-all-off')!;
 const switchesList = document.querySelector<HTMLElement>('#switches-list')!;
 const switchesCount = document.querySelector<HTMLElement>('#switches-count')!;
+const traceSimulationToggle = document.querySelector<HTMLLabelElement>('#trace-simulation-toggle')!;
+const traceSimulationEnabledInput = document.querySelector<HTMLInputElement>('#trace-simulation-enabled')!;
+const traceSimulationState = document.querySelector<HTMLElement>('#trace-simulation-state')!;
 const openGraphsButton = document.querySelector<HTMLButtonElement>('#open-graphs')!;
 const closeGraphsButton = document.querySelector<HTMLButtonElement>('#close-graphs')!;
 const graphDialog = document.querySelector<HTMLDialogElement>('#graph-dialog')!;
@@ -335,6 +343,7 @@ let historyWaveform: Waveform = emptyWaveform;
 let historyTraceCycles: number[] = [];
 let traceCycleDisplayOffset = 0;
 let traceShowActualCycles = false;
+let traceSimulationEnabled = true;
 let currentSnapshots: SnapshotInfo[] = [];
 let currentWaveform: Waveform = emptyWaveform;
 let selectedWaveformSignal: WaveformSignal | undefined;
@@ -389,6 +398,12 @@ switchesAllOnButton.addEventListener('click', () => {
 
 switchesAllOffButton.addEventListener('click', () => {
   void setAllSwitches(false).catch(error => {
+    renderSimulationError(error);
+  });
+});
+
+traceSimulationEnabledInput.addEventListener('change', () => {
+  void setTraceSimulationEnabled(traceSimulationEnabledInput.checked).catch(error => {
     renderSimulationError(error);
   });
 });
@@ -1237,14 +1252,14 @@ async function toggleSelectedSwitch(): Promise<void> {
 async function toggleSwitchBlock(block: StructureBlock): Promise<void> {
   if (!currentNbtBytes) return;
 
-  simulation ??= await NbtSimulation.create(currentNbtBytes);
+  const activeSimulation = await ensureSimulation();
 
   const selectedPos = block.pos;
   const baseRoot = currentRoot;
-  const nextRoot = simulation.toggleSwitch(block);
+  const nextRoot = activeSimulation.toggleSwitch(block);
   if (!nextRoot) return;
 
-  await applySimulatedRoot(simulation, nextRoot, baseRoot, selectedPos);
+  await applySimulatedRoot(activeSimulation, nextRoot, baseRoot, selectedPos);
 }
 
 async function setAllSwitches(isOn: boolean): Promise<void> {
@@ -1254,19 +1269,40 @@ async function setAllSwitches(isOn: boolean): Promise<void> {
   const switches = structure?.blocks.filter(block => block.palette.name === 'minecraft:lever') ?? [];
   if (switches.length === 0) return;
 
-  simulation ??= await NbtSimulation.create(currentNbtBytes);
+  const activeSimulation = await ensureSimulation();
 
   const selectedPos = selectedBlock?.pos;
   const baseRoot = currentRoot;
   let nextRoot: unknown | undefined;
 
   for (const block of switches) {
-    nextRoot = simulation.setSwitch(block, isOn) ?? nextRoot;
+    nextRoot = activeSimulation.setSwitch(block, isOn) ?? nextRoot;
   }
 
   if (!nextRoot) return;
 
-  await applySimulatedRoot(simulation, nextRoot, baseRoot, selectedPos);
+  await applySimulatedRoot(activeSimulation, nextRoot, baseRoot, selectedPos);
+}
+
+async function ensureSimulation(): Promise<NbtSimulation> {
+  if (!currentNbtBytes) throw new Error('Open an NBT file before simulating switches.');
+
+  simulation ??= await NbtSimulation.create(currentNbtBytes, traceSimulationEnabled);
+  simulation.setTraceEnabled(traceSimulationEnabled);
+  return simulation;
+}
+
+async function setTraceSimulationEnabled(enabled: boolean): Promise<void> {
+  traceSimulationEnabled = enabled;
+  traceSimulationEnabledInput.checked = enabled;
+  traceSimulationToggle.classList.toggle('active', enabled);
+  traceSimulationState.textContent = enabled ? 'On' : 'Off';
+  simulation?.setTraceEnabled(enabled);
+
+  selectedWaveformSignal = undefined;
+  renderTrace([], [], emptyWaveform, undefined);
+  await restoreCurrentStructurePreview();
+  viewer.setTraceHighlights([]);
 }
 
 async function applySimulatedRoot(
@@ -1284,14 +1320,18 @@ async function applySimulatedRoot(
   viewer.setSelectedBlock(nextSelectedBlock);
   renderSelection(nextSelectedBlock);
   renderSwitches(structure);
-  renderTrace(activeSimulation.trace(), activeSimulation.snapshots(), activeSimulation.waveform(), baseRoot, {
-    animateTo: 'last',
-    history: {
-      trace: activeSimulation.historyTrace(),
-      snapshots: activeSimulation.historySnapshots(),
-      waveform: activeSimulation.historyWaveform(),
-    },
-  });
+  if (traceSimulationEnabled) {
+    renderTrace(activeSimulation.trace(), activeSimulation.snapshots(), activeSimulation.waveform(), baseRoot, {
+      animateTo: 'last',
+      history: {
+        trace: activeSimulation.historyTrace(),
+        snapshots: activeSimulation.historySnapshots(),
+        waveform: activeSimulation.historyWaveform(),
+      },
+    });
+  } else {
+    renderTrace([], [], emptyWaveform, undefined);
+  }
 }
 
 dropZone.addEventListener('dragover', event => {
@@ -1751,13 +1791,13 @@ function updateTraceCycleControls(selectedIndex: number): number {
 
 function updateTraceCycleModeControl(): void {
   traceShowActualCyclesInput.checked = traceShowActualCycles;
-  traceShowActualCyclesInput.disabled = traceCycles.length === 0 && historyTraceCycles.length === 0;
+  traceShowActualCyclesInput.disabled = !traceSimulationEnabled || (traceCycles.length === 0 && historyTraceCycles.length === 0);
 }
 
 function updateWaveformFilterControl(): void {
   const activeWaveform = getActiveWaveform();
   waveformChangedOnlyInput.checked = waveformChangedOnly;
-  waveformChangedOnlyInput.disabled = activeWaveform.signals.length === 0;
+  waveformChangedOnlyInput.disabled = !traceSimulationEnabled || activeWaveform.signals.length === 0;
 }
 
 function getCurrentWindowStartCycle(): number | undefined {
@@ -1826,10 +1866,15 @@ function renderTrace(
   historyTraceCycles = collectTraceCycles(historyTrace, historyWaveform);
   traceCycleDisplayOffset = traceCycles.length === 0 ? 0 : Math.max(0, traceCycles[0] - 1);
   traceCount.textContent =
-    trace.length === 0 && waveform.signals.length === 0
+    !traceSimulationEnabled
+      ? 'Trace off'
+      : trace.length === 0 && waveform.signals.length === 0
       ? 'No events'
       : `${trace.length} events / ${waveform.signals.length} signals`;
-  updateTraceExpandAvailability(trace.length > 0 || waveform.signals.length > 0 || historyTrace.length > 0 || historyWaveform.signals.length > 0);
+  updateTraceExpandAvailability(
+    traceSimulationEnabled &&
+      (trace.length > 0 || waveform.signals.length > 0 || historyTrace.length > 0 || historyWaveform.signals.length > 0),
+  );
   const axisCycles = getTraceAxisCycles();
   const selectedIndex = updateTraceCycleControls(
     options.animateTo === 'last'
@@ -1841,10 +1886,10 @@ function renderTrace(
   updateWaveformFilterControl();
   renderWaveformLabels();
   void renderTraceCycle(selectedIndex);
-  if (options.open || trace.length > 0) {
+  if (traceSimulationEnabled && (options.open || trace.length > 0)) {
     tracePanel.open = true;
   }
-  if (options.animateTo === 'last') {
+  if (traceSimulationEnabled && options.animateTo === 'last') {
     startTraceAnimation(getTraceAnimationTargetIndex(axisCycles));
   }
 }
@@ -1881,7 +1926,7 @@ async function renderTraceCycle(index: number): Promise<void> {
   const axisCycles = getTraceAxisCycles();
   if (index < 0 || axisCycles.length === 0) {
     traceCycleLabel.textContent = 'cycle -';
-    traceOutput.textContent = 'Run a simulation to inspect events.';
+    traceOutput.textContent = traceSimulationEnabled ? 'Run a simulation to inspect events.' : 'Trace simulation is off.';
     renderWaveform(-1);
     viewer.setTraceHighlights([]);
     await restoreCurrentStructurePreview();

--- a/tools/nbt-viewer/src/main.ts
+++ b/tools/nbt-viewer/src/main.ts
@@ -1536,7 +1536,6 @@ async function loadExamples(): Promise<void> {
   } catch (error) {
     filesList.classList.add('empty');
     filesCount.textContent = 'No examples';
-    filesPanel.open = true;
     filesList.textContent = error instanceof Error ? error.message : String(error);
   }
 }
@@ -1545,7 +1544,6 @@ function renderExampleBrowser(examples: ExampleFile[]): void {
   filesList.replaceChildren();
   filesList.classList.toggle('empty', examples.length === 0);
   filesCount.textContent = examples.length === 0 ? 'No NBT files' : `${examples.length} files`;
-  filesPanel.open = true;
 
   if (examples.length === 0) {
     filesList.textContent = 'No supported NBT files found.';

--- a/tools/nbt-viewer/src/render/StructureViewer.ts
+++ b/tools/nbt-viewer/src/render/StructureViewer.ts
@@ -12,6 +12,8 @@ type SetStructureOptions = {
 };
 
 const ROTATION_DRAG_SCALE = 300;
+const KEYBOARD_MOVE_SPEED = 0.0008;
+const PAN_MOVE_SPEED = 0.001;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.max(min, Math.min(max, value));
@@ -341,7 +343,7 @@ export class StructureViewer {
     if (vec3.squaredLength(direction) === 0) return;
 
     vec3.normalize(direction, direction);
-    vec3.scale(direction, direction, delta * Math.max(0.01, this.cDist * 0.0016));
+    vec3.scale(direction, direction, delta * Math.max(0.01, this.cDist * KEYBOARD_MOVE_SPEED));
     this.moveCamera(direction);
   }
 
@@ -369,7 +371,7 @@ export class StructureViewer {
     const direction = vec3.fromValues(dx, -dy, 0);
     if (vec3.squaredLength(direction) === 0) return;
 
-    vec3.scale(direction, direction, Math.max(0.01, this.cDist * 0.002));
+    vec3.scale(direction, direction, Math.max(0.01, this.cDist * PAN_MOVE_SPEED));
     this.rotateCameraVector(direction);
     vec3.negate(direction, direction);
     this.moveCamera(direction);

--- a/tools/nbt-viewer/src/sim/NbtSimulation.ts
+++ b/tools/nbt-viewer/src/sim/NbtSimulation.ts
@@ -8,6 +8,7 @@ type WasmModule = {
     graph_dot_with_outputs(nbtBytes: Uint8Array, metadataJson: string): RawGraphDotInfo;
     selected_graph_dot(nbtBytes: Uint8Array, folded: boolean, nodeIds: number[]): RawGraphDotInfo;
     selected_nbt(nbtBytes: Uint8Array, folded: boolean, nodeIds: number[]): unknown;
+    with_trace(nbtBytes: Uint8Array, traceEnabled: boolean): WasmSimulator;
     trace_init(nbtBytes: Uint8Array): TraceReport;
   };
 };
@@ -18,6 +19,7 @@ type WasmSimulator = {
   history_waveform(): Waveform;
   switches(): SwitchInfo[];
   snapshots(): SnapshotInfo[];
+  set_trace_enabled(enabled: boolean): void;
   structure(): unknown;
   trace(): TraceEntry[];
   toggle_switch(x: number, y: number, z: number, isOn: boolean): unknown;
@@ -128,7 +130,10 @@ function samePos(a: [number, number, number], b: [number, number, number]): bool
 }
 
 export class NbtSimulation {
-  private constructor(private readonly sim: WasmSimulator) {}
+  private constructor(
+    private readonly sim: WasmSimulator,
+    private traceEnabled: boolean,
+  ) {}
 
   static async graphDot(nbtBytes: Uint8Array, metadataJson?: string): Promise<GraphDotInfo> {
     const wasm = await loadWasmModule();
@@ -155,16 +160,22 @@ export class NbtSimulation {
     return wasm.NbtSimulator.selected_nbt(nbtBytes, folded, nodeIds);
   }
 
-  static async create(nbtBytes: Uint8Array): Promise<NbtSimulation> {
+  static async create(nbtBytes: Uint8Array, traceEnabled = true): Promise<NbtSimulation> {
     const wasm = await loadWasmModule();
     await wasm.default(resolveAssetPath(wasmBinaryPath));
 
     try {
-      return new NbtSimulation(new wasm.NbtSimulator(nbtBytes));
+      return new NbtSimulation(wasm.NbtSimulator.with_trace(nbtBytes, traceEnabled), traceEnabled);
     } catch (error) {
       const report = wasm.NbtSimulator.trace_init(nbtBytes);
       throw new NbtSimulationError(report.error ?? getErrorMessage(error), report.trace, report.snapshots, report.waveform);
     }
+  }
+
+  setTraceEnabled(enabled: boolean): void {
+    if (this.traceEnabled === enabled) return;
+    this.traceEnabled = enabled;
+    this.sim.set_trace_enabled(enabled);
   }
 
   structure(): unknown {

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -169,7 +169,7 @@ input {
 }
 
 .switches-list {
-  max-height: calc(min(38vh, 320px) - 79px);
+  max-height: calc(min(38vh, 320px) - 115px);
   overflow: auto;
   padding: 6px;
   border-top: 1px solid rgb(154 164 173 / 18%);
@@ -200,6 +200,48 @@ input {
 
 .switches-actions button:hover {
   background: rgb(255 255 255 / 12%);
+}
+
+.trace-simulation-toggle {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 30px;
+  padding: 5px 7px;
+  border: 1px solid rgb(154 164 173 / 24%);
+  border-radius: 4px;
+  background: rgb(255 255 255 / 6%);
+  color: #dce3e7;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.trace-simulation-toggle:hover {
+  background: rgb(255 255 255 / 11%);
+}
+
+.trace-simulation-toggle.active {
+  border-color: rgb(211 50 50 / 48%);
+  background: rgb(211 50 50 / 15%);
+}
+
+.trace-simulation-toggle input {
+  width: 13px;
+  height: 13px;
+  margin: 0;
+  accent-color: #d33232;
+}
+
+.trace-simulation-toggle strong {
+  color: #9ea9b3;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.trace-simulation-toggle.active strong {
+  color: #ffd0d0;
 }
 
 .switches-actions.hidden {
@@ -1006,7 +1048,7 @@ input {
   }
 
   .switches-list {
-    max-height: calc(28vh - 79px);
+    max-height: calc(28vh - 115px);
   }
 
   .switches-actions.hidden + .switches-list {

--- a/tools/nbt-viewer/src/styles.css
+++ b/tools/nbt-viewer/src/styles.css
@@ -169,7 +169,7 @@ input {
 }
 
 .switches-list {
-  max-height: calc(min(38vh, 320px) - 115px);
+  max-height: calc(min(38vh, 320px) - 79px);
   overflow: auto;
   padding: 6px;
   border-top: 1px solid rgb(154 164 173 / 18%);
@@ -181,7 +181,7 @@ input {
 
 .switches-actions {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: 1fr 1fr auto;
   gap: 6px;
   padding: 6px;
   border-top: 1px solid rgb(154 164 173 / 18%);
@@ -203,13 +203,14 @@ input {
 }
 
 .trace-simulation-toggle {
-  grid-column: 1 / -1;
-  display: grid;
-  grid-template-columns: auto 1fr auto;
+  position: relative;
+  display: inline-grid;
+  grid-template-columns: auto auto;
   align-items: center;
-  gap: 8px;
-  min-height: 30px;
-  padding: 5px 7px;
+  gap: 6px;
+  min-width: 76px;
+  min-height: 28px;
+  padding: 3px 7px;
   border: 1px solid rgb(154 164 173 / 24%);
   border-radius: 4px;
   background: rgb(255 255 255 / 6%);
@@ -222,19 +223,65 @@ input {
   background: rgb(255 255 255 / 11%);
 }
 
+.trace-simulation-toggle:focus-within {
+  outline: 1px solid rgb(255 135 135 / 62%);
+  outline-offset: 1px;
+}
+
 .trace-simulation-toggle.active {
   border-color: rgb(211 50 50 / 48%);
   background: rgb(211 50 50 / 15%);
 }
 
 .trace-simulation-toggle input {
-  width: 13px;
-  height: 13px;
-  margin: 0;
-  accent-color: #d33232;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.trace-simulation-label {
+  color: #dce3e7;
+  line-height: 1;
+}
+
+.trace-simulation-track {
+  position: relative;
+  width: 24px;
+  height: 14px;
+  border: 1px solid rgb(154 164 173 / 32%);
+  border-radius: 999px;
+  background: rgb(0 0 0 / 22%);
+}
+
+.trace-simulation-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: #9ea9b3;
+  transition:
+    left 120ms ease,
+    background 120ms ease;
+}
+
+.trace-simulation-toggle.active .trace-simulation-track {
+  border-color: rgb(255 135 135 / 44%);
+  background: rgb(211 50 50 / 32%);
+}
+
+.trace-simulation-toggle.active .trace-simulation-knob {
+  left: 12px;
+  background: #ffd0d0;
 }
 
 .trace-simulation-toggle strong {
+  display: none;
   color: #9ea9b3;
   font-size: 11px;
   font-weight: 600;
@@ -1048,7 +1095,7 @@ input {
   }
 
   .switches-list {
-    max-height: calc(28vh - 115px);
+    max-height: calc(28vh - 79px);
   }
 
   .switches-actions.hidden + .switches-list {


### PR DESCRIPTION
## Summary
- add a compact Trace toggle to the nbt viewer switch panel
- wire the toggle through TypeScript, WASM, and the Rust simulator trace limit
- stop collecting trace/waveform/snapshot data when trace is disabled while preserving switch simulation

## Verification
- cargo test --release unittest_simulator_can_reenable_trace_after_running_without_trace
- npm.cmd run build:wasm
- npm.cmd run build
- cargo test --release

Note: in-app Browser automation failed locally due a Windows sandbox spawn issue, but the dev server responded at http://127.0.0.1:5174 during manual UI review.